### PR TITLE
Added --verbose option to neu build

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -4,11 +4,12 @@ const bundler = require('../modules/bundler');
 module.exports.register = (program) => {
     program
         .command('build')
+        .option('-v, --verbose')
         .action((name, command) => {
             bundler.buildApp(() => {
                 console.log('App build was successful!');
                 commons.figlet();
-            });
+            }, name.verbose);
         });
 }
 

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -1,7 +1,7 @@
 const fse = require('fs-extra');
 const fs = require('fs');
 const archiver = require('archiver');
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 
 module.exports.bundleApp = (settings) => {
     try {
@@ -24,15 +24,12 @@ module.exports.bundleApp = (settings) => {
     }
 }
 
-module.exports.buildApp = (buildSuccessCallback = null) => {
-    exec('npm run build', (err, stdout, stderr) => {
-        if (err) {
-            console.error(stderr);
-            return;
-        }
-        else {
-            if(buildSuccessCallback)
-                buildSuccessCallback();
-        }
+module.exports.buildApp = (buildSuccessCallback = null, verbose = false) => {
+    const proc = spawn('npm run build', {
+        shell: true,
+        stdio: ['inherit', verbose ? 'inherit' : 'ignore', 'inherit'],
+    });
+    proc.on('exit', function (code) {
+        if (code == 0 && buildSuccessCallback) buildSuccessCallback();
     });
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/27774026/101261079-6e9a4b80-3702-11eb-8923-2cf7e2b571bc.png)

It was bugging me that the output from `neu build` was hidden during run, forcing me to run the underlying `npm run build` command to see full output. So I added verbosity as an option. It can be used like:
```
neu build -v
```
or
```
neu build -verbose
```

Additionally, rather than writing errors and standard output via `console.log`, I modified the build function to pipe the streams directly, thus preserving any color information that is produced by the underlying build command.