### PR TITLE
[Need Help] Refactoring: Put the downloaded binaries in a bin directory and don't rename them to the binaryName

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -27,10 +27,17 @@ module.exports.bundleApp = async (isRelease, buildSuccessCallback = null) => {
     let binaryName = settingsObj.cli.binaryName;
     try {
         await createAsarFile();
-        fse.copySync(`bin/neutralino-win.exe`, `dist/${binaryName}/${binaryName}-win.exe`);
-        fse.copySync(`bin/neutralino-linux`, `dist/${binaryName}/${binaryName}-linux`);
-        fse.copySync(`bin/neutralino-mac`, `dist/${binaryName}/${binaryName}-mac`);
-        fse.copySync(`bin/WebView2Loader.dll`, `dist/${binaryName}/WebView2Loader.dll`);
+        if (fse.existsSync(`bin`)) { // Check if new binary path is present
+            fse.copySync(`bin/neutralino-win.exe`, `dist/${binaryName}/${binaryName}-win.exe`);
+            fse.copySync(`bin/neutralino-linux`, `dist/${binaryName}/${binaryName}-linux`);
+            fse.copySync(`bin/neutralino-mac`, `dist/${binaryName}/${binaryName}-mac`);
+            fse.copySync(`bin/WebView2Loader.dll`, `dist/${binaryName}/WebView2Loader.dll`);
+        } else { // Use old paths
+            fse.copySync(`${binaryName}-win.exe`, `dist/${binaryName}/${binaryName}-win.exe`);
+            fse.copySync(`${binaryName}-linux`, `dist/${binaryName}/${binaryName}-linux`);
+            fse.copySync(`${binaryName}-mac`, `dist/${binaryName}/${binaryName}-mac`);
+            fse.copySync(`WebView2Loader.dll`, `dist/${binaryName}/WebView2Loader.dll`);
+        }
         if (isRelease) {
             // TODO: Add installers in the future
             let output = fs.createWriteStream(`dist/${binaryName}-release.zip`);

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -28,10 +28,10 @@ module.exports.bundleApp = async (isRelease, buildSuccessCallback = null) => {
     let binaryName = settingsObj.cli.binaryName;
     try {
         await createAsarFile();
-        fse.copySync(`${binaryName}-win.exe`, `dist/${binaryName}/${binaryName}-win.exe`);
-        fse.copySync(`${binaryName}-linux`, `dist/${binaryName}/${binaryName}-linux`);
-        fse.copySync(`${binaryName}-mac`, `dist/${binaryName}/${binaryName}-mac`);
-        fse.copySync(`WebView2Loader.dll`, `dist/${binaryName}/WebView2Loader.dll`);
+        fse.copySync(`bin/neutralino-win.exe`, `dist/${binaryName}/${binaryName}-win.exe`);
+        fse.copySync(`bin/neutralino-linux`, `dist/${binaryName}/${binaryName}-linux`);
+        fse.copySync(`bin/neutralino-mac`, `dist/${binaryName}/${binaryName}-mac`);
+        fse.copySync(`bin/WebView2Loader.dll`, `dist/${binaryName}/WebView2Loader.dll`);
         if (isRelease) {
             // TODO: Add installers in the future
             let output = fs.createWriteStream(`dist/${binaryName}-release.zip`);

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -1,7 +1,6 @@
 const fse = require('fs-extra');
 const fs = require('fs');
 const archiver = require('archiver');
-const { spawn } = require('child_process');
 const asar = require('asar');
 const settings = require('./settings');
 

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -55,10 +55,11 @@ module.exports.downloadAndUpdateBinaries = (callback, name) => {
 
     downloadFromRelease(() => {
         console.log('Finalizing and cleaning temp. files.');
-        fse.copySync(`${pathPrefix}temp/neutralino-win.exe`, `${pathPrefix}${name}-win.exe`);
-        fse.copySync(`${pathPrefix}temp/neutralino-linux`, `${pathPrefix}${name}-linux`);
-        fse.copySync(`${pathPrefix}temp/neutralino-mac`, `${pathPrefix}${name}-mac`);
-        fse.copySync(`${pathPrefix}temp/WebView2Loader.dll`, `${pathPrefix}WebView2Loader.dll`);
+        fse.mkdirSync(`${pathPrefix}bin`);
+        fse.copySync(`${pathPrefix}temp/neutralino-win.exe`, `${pathPrefix}bin/neutralino-win.exe`);
+        fse.copySync(`${pathPrefix}temp/neutralino-linux`, `${pathPrefix}bin/neutralino-linux`);
+        fse.copySync(`${pathPrefix}temp/neutralino-mac`, `${pathPrefix}bin/neutralino-mac`);
+        fse.copySync(`${pathPrefix}temp/WebView2Loader.dll`, `${pathPrefix}bin/WebView2Loader.dll`);
         clearDownloadCache(pathPrefix);
         if(callback)
             callback();

--- a/src/modules/runner.js
+++ b/src/modules/runner.js
@@ -15,11 +15,11 @@ module.exports.runApp = (runSuccessCallback = null, argsOpt = "") => {
             break;
         case 'linux':
             binaryCmd = `bin/neutralino-linux${args}`;
-            chmod(`bin/neutralino-linux`, 777);
+            chmod(`bin/neutralino-linux`, { execute: true });
             break;
         case 'darwin':
             binaryCmd = `bin/neutralino-mac${args}`;
-            chmod(`bin/neutralino-mac`, 777);
+            chmod(`bin/neutralino-mac`, { execute: true });
             break;
     }
     exec(binaryCmd, (err, stdout, stderr) => {

--- a/src/modules/runner.js
+++ b/src/modules/runner.js
@@ -1,28 +1,30 @@
 const { exec } = require('child_process');
 const chmod = require('chmod');
+const fse = require('fs-extra');
 const settings = require('./settings');
 
 module.exports.runApp = (runSuccessCallback = null, argsOpt = "") => {
     let settingsObj = settings.get();
     let binaryName = settingsObj.cli.binaryName;
-    let binaryCmd;
+    let binaryPath;
     let args = " --load-dir-res";
     if(argsOpt.length > 0)
         args += " " + argsOpt;
+    process.env.NL_PATH = "..";
     switch (process.platform) {
         case 'win32':
-            binaryCmd = `bin\\neutralino-win.exe${args}`;
+            binaryPath = fse.existsSync(`bin`) ? `bin\\neutralino-win.exe` : `${binaryName}-win.exe`;
             break;
         case 'linux':
-            binaryCmd = `bin/neutralino-linux${args}`;
-            chmod(`bin/neutralino-linux`, { execute: true });
+            binaryPath = fse.existsSync(`bin`) ? `bin/neutralino-linux` : `${binaryName}-linux`;
+            chmod(binaryPath, { execute: true });
             break;
         case 'darwin':
-            binaryCmd = `bin/neutralino-mac${args}`;
-            chmod(`bin/neutralino-mac`, { execute: true });
+            binaryPath = fse.existsSync(`bin`) ? `bin/neutralino-mac` : `${binaryName}-mac`;
+            chmod(binaryPath, { execute: true });
             break;
     }
-    exec(binaryCmd, (err, stdout, stderr) => {
+    exec(binaryPath + args, (err, stdout, stderr) => {
         if (err) {
             console.error(stderr);
         }

--- a/src/modules/runner.js
+++ b/src/modules/runner.js
@@ -11,15 +11,15 @@ module.exports.runApp = (runSuccessCallback = null, argsOpt = "") => {
         args += " " + argsOpt;
     switch (process.platform) {
         case 'win32':
-            binaryCmd = `${binaryName}-win.exe${args}`;
+            binaryCmd = `bin\\neutralino-win.exe${args}`;
             break;
         case 'linux':
-            binaryCmd = `./${binaryName}-linux${args}`;
-            chmod(`${binaryName}-linux`, 777);
+            binaryCmd = `bin/neutralino-linux${args}`;
+            chmod(`bin/neutralino-linux`, 777);
             break;
         case 'darwin':
-            binaryCmd = `./${binaryName}-mac${args}`;
-            chmod(`${binaryName}-mac`, 777);
+            binaryCmd = `bin/neutralino-mac${args}`;
+            chmod(`bin/neutralino-mac`, 777);
             break;
     }
     exec(binaryCmd, (err, stdout, stderr) => {


### PR DESCRIPTION
# The `run` command does not work.
## We need a way to set `NL_PATH` without editing JSON.  See [#372](https://github.com/neutralinojs/neutralinojs/issues/372)

`downloader.js` changes:
- After downloading, create a `bin` directory
- Copy the binary files to the newly-created `bin` directory

`bundler.js` changes: 
- Remove unused import
- Adjust paths to support new ones and legacy ones

`runner.js` changes:
- Adjust paths to support new ones and legacy ones
- Fix 777 chmod which could lead to vulnerabilities
- Remove unusued import

**What works**  
[x] Creating project  
[x] Bundling & running  
[ ] Using the run command (Can't use `--load-dir-res`)
[ ] Using the listen command (Same error as ^)

Error message  
```
terminate called after throwing an instance of 'nlohmann::detail::type_error'
  what():  [json.exception.type_error.302] type must be string, but is null
Aborted (core dumped)
```