### PR TITLE
Add Document root configuration

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -5,6 +5,11 @@ const asar = require('asar');
 const config = require('./config');
 const constants = require('../constants');
 
+let docRoot = (config.get().docRoot ?? '').replace(/^\//, "").replace(/\/$/, "");
+if (docRoot.length > 0) {
+    docRoot += "/";
+}
+
 async function createAsarFile() {
     console.log(`Generating ${constants.files.resourceFile}...`);
     const configObj = config.get();
@@ -13,10 +18,10 @@ async function createAsarFile() {
     const icon = configObj.modes.window.icon.replace(/^\//, "");
     let binaryName = configObj.cli.binaryName;
     fs.mkdirSync(`temp`, { recursive: true });
-    await fse.copy(`./${resourcesDir}`, `temp/${resourcesDir}`, {overwrite: true});
+    await fse.copy(`./${docRoot}${resourcesDir}`, `temp/${resourcesDir}`, {overwrite: true});
     await fse.copy(`${constants.files.configFile}`, `temp/${constants.files.configFile}`, {overwrite: true});
-    await fse.copy(`./${clientLibrary}`, `temp/${clientLibrary}`, {overwrite: true});
-    await fse.copy(`./${icon}`, `temp/${icon}`, {overwrite: true});
+    await fse.copy(`./${docRoot}${clientLibrary}`, `temp/${clientLibrary}`, {overwrite: true});
+    await fse.copy(`./${docRoot}${icon}`, `temp/${icon}`, {overwrite: true});
     await asar.createPackage('temp', `dist/${binaryName}/${constants.files.resourceFile}`);
 }
 


### PR DESCRIPTION
This PR add a new (optional) configuration to define the document root of the app server.

----

The use case is this:
I have my application in a sub directory ([As requested by the doc](https://neutralino.js.org/docs/configuration/project-structure#developing-apps-with-frontend-frameworks)).
So project structure is like that:
```
myproject
├── bin/
│   ├── WebView2Loader.dll
│   ├── neutralino-linux_armhf
│   ├── neutralino-linux_ia32
│   ├── neutralino-linux_x64
│   ├── neutralino-mac_x64
│   └── neutralino-win_x64.exe
├── myapp/
│   ├── img.jpg
│   ├── index.html
│   ├── neutralino.js
│   └── resources/
│       └── appIcon.png
├── neutralino.config.json
├── node_modules/
│   ...
└── package.json
```
With a standard Neutralino configuration, the start (internal) url of the application will be `http://localhost:12345/myapp/`.
But if I need the internal url to not start by the sub directory, I can't.

----

With this PR a new configuration can be added to tell Neutralino that the _document root_ is `myapp`:
```json
{
  "applicationId": "js.neutralino.sample",
  "defaultMode": "window",
  "port": 0,
  "url": "/",
  "docRoot": "myapp",
  "enableServer": true,
  "enableNativeAPI": true,
  "logging": {
    "enabled": true,
    "writeToLogFile": true
  },
  "nativeBlockList": [],
  "globalVariables": {
    "TEST": "Test Value"
  },
  "modes": {
    "window": {
      "title": "myapp",
      "width": 800,
      "height": 500,
      "minWidth": 400,
      "minHeight": 200,
      "fullScreen": false,
      "alwaysOnTop": false,
      "icon": "/resources/appIcon.png",
      "enableInspector": true,
      "borderless": false,
      "maximize": false,
      "hidden": false,
      "resizable": true,
      "exitProcessOnClose": true
    }
  },
  "cli": {
    "binaryName": "myapp",
    "resourcesPath": "/",
    "clientLibrary": "/neutralino.js",
    "binaryVersion": "3.0.0",
    "clientVersion": "2.0.0"
  }
}
```