### PR TITLE
Make temp directory configurable

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -5,6 +5,8 @@ const asar = require('asar');
 const config = require('./config');
 const constants = require('../constants');
 
+const tempName = config.get().cli?.temp ?? 'temp';
+
 async function createAsarFile() {
     console.log(`Generating ${constants.files.resourceFile}...`);
     const configObj = config.get();
@@ -12,16 +14,16 @@ async function createAsarFile() {
     const clientLibrary = configObj.cli.clientLibrary.replace(/^\//, "");
     const icon = configObj.modes.window.icon.replace(/^\//, "");
     let binaryName = configObj.cli.binaryName;
-    fs.mkdirSync(`temp`, { recursive: true });
-    await fse.copy(`./${resourcesDir}`, `temp/${resourcesDir}`, {overwrite: true});
-    await fse.copy(`${constants.files.configFile}`, `temp/${constants.files.configFile}`, {overwrite: true});
-    await fse.copy(`./${clientLibrary}`, `temp/${clientLibrary}`, {overwrite: true});
-    await fse.copy(`./${icon}`, `temp/${icon}`, {overwrite: true});
-    await asar.createPackage('temp', `dist/${binaryName}/${constants.files.resourceFile}`);
+    fs.mkdirSync(tempName, { recursive: true });
+    await fse.copy(`./${resourcesDir}`, `${tempName}/${resourcesDir}`, {overwrite: true});
+    await fse.copy(`${constants.files.configFile}`, `${tempName}/${constants.files.configFile}`, {overwrite: true});
+    await fse.copy(`./${clientLibrary}`, `${tempName}/${clientLibrary}`, {overwrite: true});
+    await fse.copy(`./${icon}`, `${tempName}/${icon}`, {overwrite: true});
+    await asar.createPackage(tempName, `dist/${binaryName}/${constants.files.resourceFile}`);
 }
 
 function clearBuildCache() {
-    fse.removeSync('temp');
+    fse.removeSync(tempName);
 }
 
 module.exports.bundleApp = async (isRelease) => {


### PR DESCRIPTION
This PR allow to change the name/path of the temporary build directory.

----

One of the use cases is this:
I want to be able to have my HTML application source to live at the same level than Neutralino configurations.
```
myproject/
├── bin/
│   ├── WebView2Loader.dll
│   ├── neutralino-linux_armhf
│   ├── neutralino-linux_ia32
│   ├── neutralino-linux_x64
│   ├── neutralino-mac_x64
│   └── neutralino-win_x64.exe
├── img.jpg
├── index.html
├── neutralino.config.json
├── neutralino.js
├── node_modules/
│   ...
├── package.json
└── resources/
    └── appIcon.png
```
It's currently impossible to run Neutralino because we need to set the `config.cli.resourcesPath` to `/`, and then when Neutralino build the project, it will try to copy `./*` into `./temp` which will be prevented:
```
Bundling app...
Generating res.neu...
Error: Cannot copy './' to a subdirectory of itself, 'temp/'.
```

----

With this PR, the `temp` directory can by changed to something else outside the application like `../temp` or `/tmp/`
```json
{
  "applicationId": "js.neutralino.sample",
  "defaultMode": "window",
  "port": 0,
  "url": "/",
  "enableServer": true,
  "enableNativeAPI": true,
  "logging": {
    "enabled": true,
    "writeToLogFile": true
  },
  "nativeBlockList": [],
  "globalVariables": {
    "TEST": "Test Value"
  },
  "modes": {
    "window": {
      "title": "myapp",
      "width": 800,
      "height": 500,
      "minWidth": 400,
      "minHeight": 200,
      "fullScreen": false,
      "alwaysOnTop": false,
      "icon": "/resources/appIcon.png",
      "enableInspector": true,
      "borderless": false,
      "maximize": false,
      "hidden": false,
      "resizable": true,
      "exitProcessOnClose": true
    }
  },
  "cli": {
    "binaryName": "myapp",
    "temp": "../temp",
    "resourcesPath": "/",
    "clientLibrary": "/neutralino.js",
    "binaryVersion": "3.0.0",
    "clientVersion": "2.0.0"
  }
}
```