### PR TITLE
Fix patch url path on windows

### DIFF
--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -11,7 +11,9 @@ async function makeClientLibUrl(port) {
     let configObj = config.get();
     let resourcesPath = configObj.cli.resourcesPath.replace(/^\//, '');
     let files = await recursive(resourcesPath);
-    let clientLib = files.find((file) => /neutralino\.js$/.test(file));
+    let clientLib = files
+        .find((file) => /neutralino\.js$/.test(file))
+        .replace(/\\/g, '/'); //Fix path on windows;
 
     let url = `http://localhost:${port}`;
 


### PR DESCRIPTION
Hi

Trying to get a react hot reload up and running I would get a 404 when the app asks for neutralino.js

Doing some digging i found that the patch url inserted in `index.html` is incorrect. It's `http://localhost:5000/resources\neutralino.js`, but should in my case be `http://localhost:5000/neutralino.js`. The list of `files` contains `\\` in it's paths, causing the regex on line 21 to fail replacing `/resources\\`.

![image](https://user-images.githubusercontent.com/5564813/151720511-162a6f7f-8c83-4419-b18a-6794fdf81001.png)

I assume this might be a windows thing, as it likes making paths with backslashes instead of forward-slashes, so adding the proposed replace fixes this.