### PR TITLE
Added New Script, Fixed Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 The official CLI of Neutralinojs. See neu CLI [documentation](https://neutralino.js.org/docs/cli/neu-cli/) for more details.
 
-```
+```bash
   $ npm i -g @neutralinojs/neu
 ```
 ### Requirements
 
 - Node.js v14 or above.
-- npm, npx, or yarn package manager.
+- npm or yarn package manager.
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./bin/neu.js",
   "scripts": {
     "test": "neu version",
-    "local": "node ./bin/neu.js"
+    "start": "node ./bin/neu.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "neu CLI for Neutralinojs",
   "main": "./bin/neu.js",
   "scripts": {
-    "test": "neu version"
+    "test": "neu version",
+    "local": "node ./bin/neu.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- `package.json`
  - Added New Script `start` to Run The Local neu cli command, Usage - `npm start -- version`, `--` is required to pass the arguments to the script instead of npm itself.

- `README.md`
  - Removed `npx` from the package manager list, since [npx](https://docs.npmjs.com/cli/v7/commands/npx) is used for running local or remote npm package.