### PR TITLE
Implemented Fetching And Downloading Latest Neutralino Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 The official CLI of Neutralinojs. See neu CLI [documentation](https://neutralino.js.org/docs/cli/neu-cli/) for more details.
 
-```
+```bash
   $ npm i -g @neutralinojs/neu
 ```
 ### Requirements
 
 - Node.js v14 or above.
-- npm, npx, or yarn package manager.
+- npm or yarn package manager.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The official CLI of Neutralinojs. See neu CLI [documentation](https://neutralino
 
 [MIT](LICENSE)
 
+### Contributing to Neutralinojs
+
+We really appreciate your code contributions. Please read [this contribution guide](https://neutralino.js.org/docs/contributing/framework-developer-guide#contribution-guidelines) before sending a pull request. Thanks for your contributions.
+
 ### Contributors
 
 <a href="https://github.com/neutralinojs/neutralinojs-cli/graphs/contributors">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neutralinojs/neu",
-  "version": "9.1.2",
+  "version": "9.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@neutralinojs/neu",
-      "version": "9.1.2",
+      "version": "9.2.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^4.0.2",
@@ -20,6 +20,7 @@
         "follow-redirects": "^1.13.1",
         "fs-extra": "^9.0.1",
         "recursive-readdir": "^2.2.2",
+        "semver": "^7.3.5",
         "unzipper": "^0.10.11",
         "uuid": "^8.3.2",
         "websocket": "^1.0.34"
@@ -927,6 +928,17 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -939,6 +951,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/minimatch": {
@@ -1085,11 +1105,17 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/set-value": {
@@ -1312,6 +1338,11 @@
       "engines": {
         "node": ">=0.10.32"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/zip-stream": {
       "version": "3.0.1",
@@ -2026,12 +2057,27 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "minimatch": {
@@ -2143,9 +2189,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "set-value": {
       "version": "4.1.0",
@@ -2327,6 +2376,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "zip-stream": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "follow-redirects": "^1.13.1",
     "fs-extra": "^9.0.1",
     "recursive-readdir": "^2.2.2",
+    "semver": "^7.3.5",
     "unzipper": "^0.10.11",
     "uuid": "^8.3.2",
     "websocket": "^1.0.34"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./bin/neu.js",
   "scripts": {
     "test": "neu version",
-    "local": "node ./bin/neu.js"
+    "start": "node ./bin/neu.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "neu CLI for Neutralinojs",
   "main": "./bin/neu.js",
   "scripts": {
-    "test": "neu version"
+    "test": "neu version",
+    "local": "node ./bin/neu.js"
   },
   "repository": {
     "type": "git",

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,11 +1,13 @@
 const creator = require('../modules/creator');
 const utils = require('../utils');
+const path = require('path');
 
 module.exports.register = (program) => {
     program
         .command('create <binaryName>')
         .option('-t, --template [template]')
         .action(async (binaryName, command) => {
+            binaryName = path.basename(path.resolve(binaryName))
             await creator.createApp(binaryName, command.template);
             utils.figlet();
         });

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,16 +1,42 @@
 const utils = require('../utils');
+const getVersion = require('../modules/get-version');
+const config = require('../modules/config');
+const fs = require('fs');
+const semver = require('semver');
 const downloader = require('../modules/downloader');
+
 
 module.exports.register = (program) => {
     program
         .command('update')
         .action(async (name, command) => {
             utils.checkCurrentProject();
-            await downloader.downloadAndUpdateBinaries();
-            await downloader.downloadAndUpdateClient();
+            let binaryVersion = await getVersion();
+            let clientVersion = await getVersion(true);
+            let configFile = config.get()
 
-            utils.figlet();
-            utils.log('Run "neu version" to see installed version details.');
+            if (!binaryVersion || !clientVersion) {
+                utils.error("can't fetch the latest neutralinojs version!")
+            }
+
+            if (semver.valid(binaryVersion) && semver.gt(binaryVersion, configFile?.cli?.binaryVersion)) {
+                utils.log("A Newer NeutralinoJS version is available... Downloading")
+                await downloader.downloadAndUpdateBinaries();
+                config.update('cli.binaryVersion', binaryVersion)
+            }
+
+            if (semver.valid(binaryVersion) && semver.gt(clientVersion, configFile?.cli?.clientVersion)) {
+                utils.log("A Newer NeutralinoJS client version is available... Downloading")
+                await downloader.downloadAndUpdateClient()
+                config.update('cli.clientVersion', clientVersion)
+            }
+
+            if (!fs.existsSync('bin') || fs.readdirSync('bin').length == 0) {
+                await downloader.downloadAndUpdateBinaries();
+            }
+
+            if (!fs.existsSync(configFile?.cli?.clientLibrary)) {
+                await downloader.downloadAndUpdateClient();
+            }
         });
 }
-

--- a/src/modules/get-version.js
+++ b/src/modules/get-version.js
@@ -1,0 +1,28 @@
+const https = require('https');
+const semver = require('semver');
+
+module.exports = (client = false) => {
+	return new Promise((resolve, reject) => {
+		let body = ''
+		https.get({
+			host: 'api.github.com',
+			path: client ? '/repos/neutralinojs/neutralino.js/tags' : '/repos/neutralinojs/neutralinojs/tags',
+			headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246' }
+		}, response => {
+			response.on("data", chunk => body += chunk)
+			response.on("end", () => {
+				try {
+					let releaseData = JSON.parse(body.toString())
+					let version = releaseData[0]?.name?.substring(1);
+					if (!semver.valid(version)) {
+						reject(null)
+					} else {
+						resolve(version)
+					}
+				} catch (err) {
+					reject(null);
+				}
+			})
+		});
+	});
+}


### PR DESCRIPTION
This PR implements fetching latest NeutralinoJS Binaries And Client Version From Remote, if current project has a older version then it will update it with the latest one.

`package.json`:
- Added `semver` as a dependency for Parsing and comparing version numbers

`package-lock.json`:
- Synchronized with the `package.json`

`src/modules/get-version.js`:
- Contains Function which fetches latest neutralino js binaries version, if `true` passed as an argument, it fetches the latest neutralino js client version.

`src/commands/update.js`:
- Updated The Default Function which fetches the latest neutralino js version and updates the `neutralino.config.json` accordingly and also downloads the latest binaries and client file.
- If config file is update to date but binaries or client file is not found, it downloads them.