### PR TITLE
Patched Issue #91

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,12 +1,15 @@
 const creator = require('../modules/creator');
 const utils = require('../utils');
+const path = require('path');
 
 module.exports.register = (program) => {
     program
         .command('create <binaryName>')
         .option('-t, --template [template]')
         .action(async (binaryName, command) => {
-            await creator.createApp(binaryName, command.template);
+            let projectPath = path.resolve(binaryName);
+            binaryName = path.basename(path.resolve(process.cwd(), binaryName));
+            await creator.createApp(binaryName, projectPath, command.template);
             utils.figlet();
         });
 }

--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -1,18 +1,24 @@
 const process = require('process');
 const fs = require('fs');
+const path = require('path');
 const constants = require('../constants');
 const config = require('../modules/config');
 const downloader = require('./downloader');
 const utils = require('../utils');
 
-module.exports.createApp = async (binaryName, template) => {
+module.exports.createApp = async (binaryName, projectPath, template) => {
     if(!template) {
         template = 'neutralinojs/neutralinojs-minimal';
     }
-    utils.log(`Downloading ${template} template to ${binaryName} directory...`);
 
-    fs.mkdirSync(binaryName, { recursive: true });
-    process.chdir(binaryName); // Change the path context for the following methods
+    // Get the relative path. if path is '' which means "./" then value should be binary name, else it should be the relative path
+    const projectPathRel = path.relative('.', projectPath) ? path.relative('.', projectPath) : binaryName;
+    utils.log(`Downloading ${template} template to ${projectPathRel} directory...`);
+
+    if (!fs.existsSync(projectPath)) {
+        fs.mkdirSync(projectPath, { recursive: true });
+    }
+    process.chdir(projectPath); // Change the path context for the following methods
 
     try {
         await downloader.downloadTemplate(template);
@@ -29,5 +35,5 @@ module.exports.createApp = async (binaryName, template) => {
     config.update('modes.window.title', binaryName);
 
     console.log('-------');
-    utils.log(`Enter 'cd ${binaryName} && neu run' to run your application.`);
+    utils.log(`Enter 'cd ${projectPathRel} && neu run' to run your application.`);
 }


### PR DESCRIPTION
Passing `.` Or `../` in `neu create` causes issues, one of the issue was #91 Which has been fixed in this pr.

Instead of putting the `.` or `../` as binary name in the config, this patch converts the provided app name into a path, and gets the base name of the directory from the path and uses that as the binary name.