### PR TITLE
Throw error in case app name already exists in current directory

### DIFF
--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -5,6 +5,10 @@ const downloader = require('./downloader');
 const utils = require('../utils');
 
 module.exports.createApp = async (binaryName, template) => {
+    if (fs.existsSync(`./${binaryName}`)) {
+        utils.error('App name already exists');
+        process.exit(1);
+    }
     if(!template) {
         template = 'neutralinojs/neutralinojs-minimal';
     }


### PR DESCRIPTION
- If there exits an app with same name as new one being created, throw error and end `create` process.
- fixes #122 
cc : @shalithasuranga 