### PR TITLE
Make temporary directories consistent with the other parts of the framework

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -15,22 +15,22 @@ async function createAsarFile() {
     const icon = utils.trimPath(configObj.modes.window.icon);
     const binaryName = configObj.cli.binaryName;
 
-    fs.mkdirSync(`temp`, { recursive: true });
-    await fse.copy(`./${resourcesDir}`, `temp/${resourcesDir}`, {overwrite: true});
+    fs.mkdirSync(`.tmp`, { recursive: true });
+    await fse.copy(`./${resourcesDir}`, `.tmp/${resourcesDir}`, {overwrite: true});
 
     if(extensionsDir && fs.existsSync(extensionsDir)) {
         await fse.copy(`./${extensionsDir}`, `dist/${binaryName}/${extensionsDir}`, {overwrite: true});
     }
 
-    await fse.copy(`${constants.files.configFile}`, `temp/${constants.files.configFile}`, {overwrite: true});
-    await fse.copy(`./${clientLibrary}`, `temp/${clientLibrary}`, {overwrite: true});
-    await fse.copy(`./${icon}`, `temp/${icon}`, {overwrite: true});
+    await fse.copy(`${constants.files.configFile}`, `.tmp/${constants.files.configFile}`, {overwrite: true});
+    await fse.copy(`./${clientLibrary}`, `.tmp/${clientLibrary}`, {overwrite: true});
+    await fse.copy(`./${icon}`, `.tmp/${icon}`, {overwrite: true});
 
-    await asar.createPackage('temp', `dist/${binaryName}/${constants.files.resourceFile}`);
+    await asar.createPackage('.tmp', `dist/${binaryName}/${constants.files.resourceFile}`);
 }
 
 function clearBuildCache() {
-    fse.removeSync('temp');
+    fse.removeSync('.tmp');
 }
 
 module.exports.bundleApp = async (isRelease, copyStorage) => {

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -24,15 +24,15 @@ let getRepoNameFromTemplate = (template) => {
 
 let downloadBinariesFromRelease = () => {
     return new Promise((resolve, reject) => {
-        fs.mkdirSync('temp', { recursive: true });
-        const file = fs.createWriteStream('temp/binaries.zip');
+        fs.mkdirSync('.tmp', { recursive: true });
+        const file = fs.createWriteStream('.tmp/binaries.zip');
         utils.log('Downloading Neutralinojs binaries..');
         https.get(getBinaryDownloadUrl(), function (response) {
             response.pipe(file);
             response.on('end', () => {
                 utils.log('Extracting zip file..');
-                fs.createReadStream('temp/binaries.zip')
-                    .pipe(unzipper.Extract({ path: 'temp/' }))
+                fs.createReadStream('.tmp/binaries.zip')
+                    .pipe(unzipper.Extract({ path: '.tmp/' }))
                     .promise()
                         .then(() => resolve())
                         .catch((e) => reject(e));
@@ -43,8 +43,8 @@ let downloadBinariesFromRelease = () => {
 
 let downloadClientFromRelease = () => {
     return new Promise((resolve, reject) => {
-        fs.mkdirSync('temp', { recursive: true });
-        const file = fs.createWriteStream('temp/neutralino.js');
+        fs.mkdirSync('.tmp', { recursive: true });
+        const file = fs.createWriteStream('.tmp/neutralino.js');
         utils.log('Downloading the Neutralinojs client..');
         https.get(getClientDownloadUrl(), function (response) {
             response.pipe(file);
@@ -57,23 +57,23 @@ let downloadClientFromRelease = () => {
 }
 
 let clearDownloadCache = () => {
-    fse.removeSync('temp');
+    fse.removeSync('.tmp');
 }
 
 module.exports.downloadTemplate = (template) => {
     return new Promise((resolve, reject) => {
         let templateUrl = constants.remote.templateUrl.replace('{template}', template);
-        fs.mkdirSync('temp', { recursive: true });
-        const file = fs.createWriteStream('temp/template.zip');
+        fs.mkdirSync('.tmp', { recursive: true });
+        const file = fs.createWriteStream('.tmp/template.zip');
         https.get(templateUrl, function (response) {
             response.pipe(file);
             response.on('end', () => {
                 utils.log('Extracting template zip file..');
-                fs.createReadStream('temp/template.zip')
-                    .pipe(unzipper.Extract({ path: 'temp/' }))
+                fs.createReadStream('.tmp/template.zip')
+                    .pipe(unzipper.Extract({ path: '.tmp/' }))
                     .promise()
                         .then(() => {
-                            fse.copySync(`temp/${getRepoNameFromTemplate(template)}-main`, '.');
+                            fse.copySync(`.tmp/${getRepoNameFromTemplate(template)}-main`, '.');
                             clearDownloadCache();
                             resolve();
                         })
@@ -92,12 +92,12 @@ module.exports.downloadAndUpdateBinaries = async () => {
     for(let platform in constants.files.binaries) {
         for(let arch in constants.files.binaries[platform]) {
             let binaryFile = constants.files.binaries[platform][arch];
-            fse.copySync(`temp/${binaryFile}`, `bin/${binaryFile}`);
+            fse.copySync(`.tmp/${binaryFile}`, `bin/${binaryFile}`);
         }
     }
 
     for(let dependency of constants.files.dependencies) {
-        fse.copySync(`temp/${dependency}`,`bin/${dependency}`);
+        fse.copySync(`.tmp/${dependency}`,`bin/${dependency}`);
     }
     clearDownloadCache();
 }
@@ -107,7 +107,7 @@ module.exports.downloadAndUpdateClient = async () => {
     const clientLibrary = utils.trimPath(configObj.cli.clientLibrary);
     await downloadClientFromRelease();
     utils.log('Finalizing and cleaning temp. files...');
-    fse.copySync(`temp/${constants.files.clientLibrary}`, `./${clientLibrary}`);
+    fse.copySync(`.tmp/${constants.files.clientLibrary}`, `./${clientLibrary}`);
     clearDownloadCache()
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,7 +43,7 @@ let trimPath = (path) => {
 }
 
 let clearCache = () => {
-    fse.removeSync('temp');
+    fse.removeSync('.tmp');
 }
 
 module.exports = {


### PR DESCRIPTION
Renamed temporary directories to ``.tmp`` to make it consistent with other parts of the framework. (suggested by @shalithasuranga [here](https://discord.com/channels/869948661084340265/926731022316478474/964162508132859956))