### PR TITLE
Exclude testNeuCLI folder from git tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # Misc
 .DS_Store
+
+# test directory
+/testNeuCLI


### PR DESCRIPTION
#### What this PR does?

Adds ``/testNeuCLI`` to ``.gitignore`` so that it gets convenient to add, commit and push while, also running, repeated ``test_commands.sh`` tests alongside.