### PR TITLE
Remove testNeuCLI folder recursively from previous test runs

### DIFF
--- a/scripts/test_commands.sh
+++ b/scripts/test_commands.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+#remove /testNeuCLI folder from previous test runs
+rm -rf testNeuCLI
+
 mkdir testNeuCLI
 cd testNeuCLI
 


### PR DESCRIPTION
Currently, the ``test_commands.sh``  script creates a folder by the name ``testNeuCLI``. Repeatitive  ``npm test`` runs will throw an errors as follows. 

![image](https://user-images.githubusercontent.com/76606666/163488442-51325fb1-2ced-4529-a67a-c3f1e3774880.png)

### Fix
Add ``rm -rf testNeuCLI`` at the start of ``test_commands.sh`` so that test results from previous runs are deleted before running another test