### PR TITLE
Remove redundant --save in pluginloader module

### DIFF
--- a/src/plugins/pluginloader.js
+++ b/src/plugins/pluginloader.js
@@ -37,7 +37,7 @@ let add = (pluginName) => {
         if(config.has('plugins'))
             plugins = config.get('plugins');
         if(!isPluginInstalled(pluginName)) {
-            exec(`cd ${NEU_ROOT} && npm install --save ${pluginName}`, (err, stdout, stderr) => {
+            exec(`cd ${NEU_ROOT} && npm install ${pluginName}`, (err, stdout, stderr) => {
                 if(err) {
                     reject(stderr);
                 }


### PR DESCRIPTION
``--save`` is redundant with npm 5.0.0 (or above) which was released in 2017 (5 years ago).

##### Reference : [Npm 5.0.0 release blog](https://blog.npmjs.org/post/161081169345/v500.html)