### PR TITLE
Add --export-auth-info only if set true in config.json

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -37,6 +37,10 @@ module.exports.register = (program) => {
                 argsOpt += ` --url=${configObj.cli.frontendLibrary.devUrl}`
             }
 
+            if(configObj.exportAuthInfo) {
+                argsOpt += "--export-auth-info";
+            }
+
             try {
                 await runner.runApp({argsOpt,
                                     arch: command.arch});

--- a/src/modules/runner.js
+++ b/src/modules/runner.js
@@ -32,7 +32,7 @@ module.exports.runApp = async (options = {}) => {
         }
 
         let binaryPath = `bin${path.sep}${binaryName}`;
-        let args = " --load-dir-res --path=. --export-auth-info --neu-dev-extension";
+        let args = " --load-dir-res --path=. --neu-dev-extension";
         if(options.argsOpt)
             args += " " + options.argsOpt;
 


### PR DESCRIPTION
Fixes neutralinojs/neutralinojs#892
- To export auth info, set `"exportAuthInfo": true"` in neutralino.config.json
- By default, export auth info will be set true. I will drop PRs for the same