### PR TITLE
added local testing for plugin development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neutralinojs/neu",
-  "version": "9.3.1",
+  "version": "9.4.0",
   "description": "neu CLI for Neutralinojs",
   "main": "./bin/neu.js",
   "scripts": {

--- a/src/commands/plugins.js
+++ b/src/commands/plugins.js
@@ -1,36 +1,39 @@
-const pluginloader = require('../plugins/pluginloader');
-const utils = require('../utils');
+const pluginloader = require("../plugins/pluginloader");
+const utils = require("../utils");
 
 module.exports.register = (program) => {
-    program
-        .command('plugins [plugin]')
-        .description('displays, adds or removes plugins')
-        .option('-a, --add')
-        .option('-r, --remove')
-        .action(async (plugin, command) => {
-            if(plugin) {
-                if(command.add) {
-                    try {
-                        utils.log(`Installing ${plugin}..`);
-                        await pluginloader.add(plugin);
-                        utils.log(`${plugin} was installed!`);
-                    }
-                    catch(e) {
-                        utils.error(e);
-                    }
-                }
-                else if(command.remove)
-                    try {
-                        utils.log(`Uninstalling ${plugin}..`);
-                        await pluginloader.remove(plugin);
-                        utils.log(`${plugin} was uninstalled!`);
-                    }
-                    catch(e) {
-                        utils.error(e);
-                    }
-            }
-            else
-                pluginloader.list(plugin);
-        });
-}
-
+  program
+    .command("plugins [plugin]")
+    .description("displays, adds or removes plugins")
+    .option("-a, --add")
+    .option("-r, --remove")
+    .option("-t, --test")
+    .action(async (plugin, command) => {
+      if (plugin) {
+        if (command.add) {
+          try {
+            utils.log(`Installing ${plugin}..`);
+            command.test
+              ? await pluginloader.addTest(plugin)
+              : await pluginloader.add(plugin);
+            utils.log(
+              `${plugin} was installed ${command.test && "in test mode"} `
+            );
+          } catch (e) {
+            utils.error(e);
+          }
+        } else if (command.remove)
+          try {
+            utils.log(`Uninstalling ${plugin}..`);
+            command.test
+              ? await pluginloader.removeTest(plugin)
+              : await pluginloader.remove(plugin);
+            utils.log(`${plugin} was uninstalled!`);
+          } catch (e) {
+            utils.error(e);
+          }
+      } else {
+        pluginloader.list(plugin);
+      }
+    });
+};

--- a/src/plugins/pluginloader.js
+++ b/src/plugins/pluginloader.js
@@ -1,97 +1,216 @@
-
-const path = require('path');
-const { exec } = require('child_process');
-const package = require('../../package.json');
-const NEU_ROOT = path.join(__dirname, '../../');
-const Configstore = require('configstore');
+const path = require("path");
+const fs = require("fs");
+const { exec } = require("child_process");
+const package = require("../../package.json");
+const NEU_ROOT = path.join(__dirname, "../../");
+const Configstore = require("configstore");
 const config = new Configstore(package.name);
-const utils = require('../utils');
+const utils = require("../utils");
 
 module.exports.registerPlugins = async (program, modules) => {
-    if(!config.has('plugins'))
-        return;
-    for(let pluginName of config.get('plugins')) {
-        try {
-            let plugin = require(pluginName);
-            if(plugin.register && plugin.command)
-                plugin.register(program.command(plugin.command), modules);
-            else
-                utils.error(`Plugin ${pluginName} should export command and register properties.`);
-        }
-        catch(e) {
-            utils.error(`Unable to load ${pluginName} plugin.`);
-            try {
-                utils.log(`Attempting to install ${pluginName}`);
-                await add(pluginName);
-            }
-            catch(e) {
-                utils.error(e);
-            }
-        }
+  if (!config.has("plugins")) return;
+  for (let pluginName of config.get("plugins")) {
+    try {
+      let plugin = require(pluginName);
+      if (plugin.register && plugin.command)
+        plugin.register(program.command(plugin.command), modules);
+      else
+        utils.error(
+          `Plugin ${pluginName} should export command and register properties.`
+        );
+    } catch (e) {
+      utils.error(`Unable to load ${pluginName} plugin.`);
+      try {
+        utils.log(`Attempting to install ${pluginName}`);
+        await add(pluginName);
+      } catch (e) {
+        utils.error(e);
+      }
     }
-}
+  }
+};
 
 let add = (pluginName) => {
-    return new Promise((resolve, reject) => {
-        let plugins = [];
-        if(config.has('plugins'))
-            plugins = config.get('plugins');
-        if(!isPluginInstalled(pluginName)) {
-            exec(`cd ${NEU_ROOT} && npm install ${pluginName}`, (err, stdout, stderr) => {
-                if(err) {
-                    reject(stderr);
-                }
-                else if(!plugins.includes(pluginName)) {
-                    plugins.push(pluginName);
-                    config.set('plugins', plugins);
-                }
-                resolve();
-            });
+  return new Promise((resolve, reject) => {
+    let plugins = [];
+    if (config.has("plugins")) plugins = config.get("plugins");
+    if (!isPluginInstalled(pluginName)) {
+      exec(
+        `cd ${NEU_ROOT} && npm install ${pluginName}`,
+        (err, stdout, stderr) => {
+          if (err) {
+            reject(stderr);
+          } else if (!plugins.includes(pluginName)) {
+            plugins.push(pluginName);
+            config.set("plugins", plugins);
+          }
+          resolve();
         }
-        else {
-            reject(`${pluginName} is already installed!`);
+      );
+    } else {
+      reject(`${pluginName} is already installed!`);
+    }
+  });
+};
+
+module.exports.addTest = (pluginPath) => {
+  let statsObj;
+  try {
+    statsObj = fs.statSync(pluginPath);
+  } catch (e) {
+    utils.error(`${e.message}`);
+
+    process.exit(1);
+  }
+
+  if (!statsObj.isDirectory() || !fs.existsSync(pluginPath)) {
+    utils.error(`${pluginPath} is not a valid path`);
+
+    process.exit(1);
+  }
+
+  const packageJson = require(path.join(pluginPath, "package.json"));
+  if (!packageJson) {
+    utils.error("Cannot find package.json file");
+
+    process.exit(1);
+  }
+
+  const pluginName = packageJson.name;
+  if (!pluginName) {
+    utils.error("Your plugin has no name. Please add name in package.json");
+
+    process.exit(1);
+  }
+
+  return new Promise((resolve, reject) => {
+    let plugins = [];
+    if (config.has("plugins")) plugins = config.get("plugins");
+    if (!isPluginInstalled(pluginName)) {
+      exec(`cd ${pluginPath} && npm link`, (err, stdout, stderr) => {
+        if (err) {
+          reject(stderr);
+        } else if (!plugins.includes(pluginName)) {
+          plugins.push(pluginName);
+          config.set("plugins", plugins);
         }
-    });
+        resolve();
+      });
+
+      exec(
+        `cd ${NEU_ROOT} && npm install ${pluginPath}`,
+        (err, stdout, stderr) => {
+          if (err) {
+            reject(stderr);
+          } else if (!plugins.includes(pluginName)) {
+            plugins.push(pluginName);
+            config.set("plugins", plugins);
+          }
+          resolve();
+        }
+      );
+    } else {
+      reject(`${pluginName} is already installed!`);
+    }
+  });
 };
 
 let isPluginInstalled = (pluginName) => {
-    try {
-        require.resolve(pluginName);
-        return true;
-    }
-    catch (e) {
-        return false;
-    }
-}
+  try {
+    require.resolve(pluginName);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
 
 module.exports.remove = (pluginName, uninstallSuccessCallback) => {
-    return new Promise((resolve, reject) => {
-        let plugins = [];
-        if(config.has('plugins'))
-            plugins = config.get('plugins');
-        if(plugins.includes(pluginName)) {
-            exec(`cd ${NEU_ROOT} && npm uninstall --save ${pluginName}`, (err, stdout, stderr) => {
-                if (err) {
-                    reject(stderr);
-                }
-                else {
-                    plugins.splice(plugins.indexOf(pluginName), 1);
-                    config.set('plugins', plugins);
-                    resolve();
-                }
-            });
+  return new Promise((resolve, reject) => {
+    let plugins = [];
+    if (config.has("plugins")) plugins = config.get("plugins");
+    if (plugins.includes(pluginName)) {
+      exec(
+        `cd ${NEU_ROOT} && npm uninstall --save ${pluginName}`,
+        (err, stdout, stderr) => {
+          if (err) {
+            reject(stderr);
+          } else {
+            plugins.splice(plugins.indexOf(pluginName), 1);
+            config.set("plugins", plugins);
+            resolve();
+          }
         }
-        else {
-            reject(`Unable to find ${pluginName}!`);
+      );
+    } else {
+      reject(`Unable to find ${pluginName}!`);
+    }
+  });
+};
+
+module.exports.removeTest = (pluginPath, uninstallSuccessCallback) => {
+  let pluginName, packageJson, statsObj;
+
+  try {
+    statsObj = fs.statSync(pluginPath);
+  } catch (e) {
+    pluginName = pluginPath;
+  }
+
+  if (!pluginName && (!statsObj?.isDirectory() || !fs.existsSync(pluginPath))) {
+    utils.error(`${pluginPath} is not a valid file path`);
+
+    process.exit(1);
+  } else {
+    packageJson = require(path.join(pluginPath, "package.json"));
+    if (!packageJson) {
+      utils.error("Cannot find package.json file");
+
+      process.exit(1);
+    }
+
+    pluginName = packageJson.name;
+    if (!pluginName) {
+      utils.error("Your plugin has no name. Please add name in package.json");
+
+      process.exit(1);
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    let plugins = [];
+    if (config.has("plugins")) plugins = config.get("plugins");
+    if (plugins.includes(pluginName)) {
+      exec(`npm rm -g ${pluginName}`, (err, stdout, stderr) => {
+        if (err) {
+          reject(stderr);
+        } else {
+          plugins.splice(plugins.indexOf(pluginName), 1);
+          config.set("plugins", plugins);
+          resolve();
         }
-    });
+      });
+
+      exec(
+        `cd ${NEU_ROOT} && npm uninstall ${pluginName}`,
+        (err, stdout, stderr) => {
+          if (err) {
+            reject(stderr);
+          } else {
+            plugins.splice(plugins.indexOf(pluginName), 1);
+            config.set("plugins", plugins);
+            resolve();
+          }
+        }
+      );
+    } else {
+      reject(`Unable to find ${pluginName}!`);
+    }
+  });
 };
 
 module.exports.list = () => {
-    if(!config.has('plugins'))
-        return;
-    for(let plugin of config.get('plugins'))
-        console.log(plugin);
-}
+  if (!config.has("plugins")) return;
+  for (let plugin of config.get("plugins")) console.log(plugin);
+};
 
 module.exports.add = add;


### PR DESCRIPTION
I added a feature to allow local testing during plugin development. All you have to do is add the "--test" option when adding a plugin, and the plugin must be written as the path of the plugin directory, it is advisable you use an absolute path, not a relative path.

Example:  "neu plugins --add --test <b> plugin path </b>".

You can also remove the plugin by adding the "--test" option when removing the plugin. The plugin can be written as either the it's path or just the plugin name

Example:  "neu plugins --remove --test <b> plugin path / plugin name </b>".