### PR TITLE
Add error handling to neu build --copy-storage command

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -52,7 +52,13 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
 
         if(copyStorage) {
             utils.log('Copying storage data...');
-            fse.copySync(`.storage`,`dist/${binaryName}/.storage`);
+            try{
+                fse.copySync(`.storage`,`dist/${binaryName}/.storage`);
+            }
+            catch(err){
+                utils.error('Unable to copy from .storage directory. Please check if the directory exists');
+                process.exit(1);
+            }
         }
 
         if (isRelease) {

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -52,11 +52,11 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
 
         if(copyStorage) {
             utils.log('Copying storage data...');
-            try{
+            try {
                 fse.copySync(`.storage`,`dist/${binaryName}/.storage`);
             }
-            catch(err){
-                utils.error('Unable to copy from .storage directory. Please check if the directory exists');
+            catch(err) {
+                utils.error('Unable to copy storage data from the .storage directory. Please check if the directory exists');
                 process.exit(1);
             }
         }

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -53,7 +53,7 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
         if(copyStorage) {
             utils.log('Copying storage data...');
             try {
-                fse.copySync(`.storage`,`dist/${binaryName}/.storage`);
+                fse.copySync('.storage',`dist/${binaryName}/.storage`);
             }
             catch(err) {
                 utils.error('Unable to copy storage data from the .storage directory. Please check if the directory exists');


### PR DESCRIPTION
- Currently, `neu build --copy-storage` throws no error in case the `.storage` directory is not found.
- Improved error handling in the following pull request.