### PR TITLE
Add feature to customize distribution path

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -12,7 +12,7 @@ module.exports.register = (program) => {
             utils.log('Bundling app...');
             await bundler.bundleApp(command.release, command.copyStorage);
             utils.showArt();
-            utils.log('Application package was generated at the ./dist directory!');
+            utils.log('Application package was generated at the configured distribution path!');
             utils.log('Distribution guide: https://neutralino.js.org/docs/distribution/overview');
         });
 }

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -12,6 +12,8 @@ async function createAsarFile() {
     const resourcesDir = utils.trimPath(configObj.cli.resourcesPath);
     const extensionsDir = utils.trimPath(configObj.cli.extensionsPath);
     const clientLibrary = utils.trimPath(configObj.cli.clientLibrary);
+    const distributionPath = utils.trimPath(configObj.distributionPath);
+
     const icon = utils.trimPath(configObj.modes.window.icon);
     const binaryName = configObj.cli.binaryName;
 
@@ -19,19 +21,20 @@ async function createAsarFile() {
     await fse.copy(`./${resourcesDir}`, `.tmp/${resourcesDir}`, {overwrite: true});
 
     if(extensionsDir && fs.existsSync(extensionsDir)) {
-        await fse.copy(`./${extensionsDir}`, `dist/${binaryName}/${extensionsDir}`, {overwrite: true});
+        await fse.copy(`./${extensionsDir}`, `${distributionPath}/${binaryName}/${extensionsDir}`, {overwrite: true});
     }
 
     await fse.copy(`${constants.files.configFile}`, `.tmp/${constants.files.configFile}`, {overwrite: true});
     await fse.copy(`./${clientLibrary}`, `.tmp/${clientLibrary}`, {overwrite: true});
     await fse.copy(`./${icon}`, `.tmp/${icon}`, {overwrite: true});
 
-    await asar.createPackage('.tmp', `dist/${binaryName}/${constants.files.resourceFile}`);
+    await asar.createPackage('.tmp', `${distributionPath}/${binaryName}/${constants.files.resourceFile}`);
 }
 
 module.exports.bundleApp = async (isRelease, copyStorage) => {
     let configObj = config.get();
     let binaryName = configObj.cli.binaryName;
+    let distributionPath = utils.trimPath(configObj.distributionPath);
     try {
         await createAsarFile();
         utils.log('Copying binaries...');
@@ -41,19 +44,19 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
                 let originalBinaryFile = constants.files.binaries[platform][arch];
                 let destinationBinaryFile = originalBinaryFile.replace('neutralino', binaryName);
                 if(fse.existsSync(`bin/${originalBinaryFile}`)) {
-                    fse.copySync(`bin/${originalBinaryFile}`, `dist/${binaryName}/${destinationBinaryFile}`);
+                    fse.copySync(`bin/${originalBinaryFile}`, `${distributionPath}/${binaryName}/${destinationBinaryFile}`);
                 }
             }
         }
 
         for(let dependency of constants.files.dependencies) {
-            fse.copySync(`bin/${dependency}`,`dist/${binaryName}/${dependency}`);
+            fse.copySync(`bin/${dependency}`,`${distributionPath}/${binaryName}/${dependency}`);
         }
 
         if(copyStorage) {
             utils.log('Copying storage data...');
             try {
-                fse.copySync('.storage',`dist/${binaryName}/.storage`);
+                fse.copySync('.storage',`${distributionPath}/${binaryName}/.storage`);
             }
             catch(err) {
                 utils.error('Unable to copy storage data from the .storage directory. Please check if the directory exists');
@@ -63,10 +66,10 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
 
         if (isRelease) {
             utils.log('Making app bundle ZIP file...');
-            let output = fs.createWriteStream(`dist/${binaryName}-release.zip`);
+            let output = fs.createWriteStream(`${distributionPath}/${binaryName}-release.zip`);
             let archive = archiver('zip', { zlib: { level: 9 } });
             archive.pipe(output);
-            archive.directory(`dist/${binaryName}`, false);
+            archive.directory(`${distributionPath}/${binaryName}`, false);
             await archive.finalize();
         }
         utils.clearCache();


### PR DESCRIPTION
- Fixes #178 

## Testing it
- Edit the `neutralino.config.json` with, for example : `"distributionPath": "/dist-game/"`  field added to it.
- Run `neu build` or `neu build --release` or `neu build --copy-storage`
- The distribution files corresponding to the build command gets loaded in the customized distribution path provided in the config (`dist-game` in this case).