### PR TITLE
Initial test for neu run command

### DIFF
--- a/spec/run.spec.js
+++ b/spec/run.spec.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const runner = require('./runner');
+
+describe('Run neu run command and its options', () => {
+    describe('Test neu run --help command', () => {
+        it('returns output of neu run --help', async() => {
+            let output = runner.run('neu run --help');
+
+            assert.equal(output.error, null);
+            assert.equal(output.status, 0);
+            assert.ok(typeof output.data == 'string');
+            assert.ok(output.data.includes('Usage: neu run [options]'));
+        });
+    });
+});


### PR DESCRIPTION
@shalithasuranga Need discussion on how to test commands that open neutralinojs app. The further tests gets halted in case a command runs to open a neutralinojs app. We can however use OS specific commands to get the app closed to check for expected output. This implementation will however require different tests for different operating systems.

I have checked out tests that run on the main framework. Its very clear that these tests become redundant here. So I don't find a point in adding tests here. However I created a file for `neu run` tests to keep things consistent and in case new tests need to be added later. Please let me know in this regard.