### PR TITLE
Replace unzipper module with decompress

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "chokidar": "^3.5.1",
     "commander": "^7.2.0",
     "configstore": "^5.0.1",
+    "decompress": "^4.2.1",
     "edit-json-file": "^1.6.2",
     "figlet": "^1.5.0",
     "follow-redirects": "^1.13.1",
     "fs-extra": "^9.0.1",
     "recursive-readdir": "^2.2.2",
-    "unzipper": "^0.10.11",
     "uuid": "^8.3.2",
     "websocket": "^1.0.34"
   },


### PR DESCRIPTION
Replaced `unzipper` module with `decompress` because it:

- corrupts extracted files with Node 18+
- has lot of open issues, including [this one](https://github.com/neutralinojs/neutralinojs-cli/issues/200) related to decompression corruption
