### PR TITLE
fixed userdata directory issue - "Google Chrome cannot read and write to its data directory"

### DIFF
--- a/src/modules/runner.js
+++ b/src/modules/runner.js
@@ -26,7 +26,7 @@ module.exports.runApp = async (options = {}) => {
         }
 
         let binaryPath = `bin${path.sep}${binaryName}`;
-        let args = " --load-dir-res --path=. --export-auth-info --neu-dev-extension";
+        let args = ` --load-dir-res --path=${path.resolve('.')} --export-auth-info --neu-dev-extension`;
         if(options.argsOpt)
             args += " " + options.argsOpt;
 


### PR DESCRIPTION
I am getting this issue while having (Google Chrome Version 112.0.5615.138)
`"defaultMode": "chrome"`

![2023-04-25_21h39_03](https://user-images.githubusercontent.com/4664063/234344044-171dfd49-09f7-45e4-aeb7-ae76c73c4c92.png)

this link here [https://stackoverflow.com/questions/67198271/google-chrome-cannot-read-and-write-to-its-data-directory-selenium](url) says its related to relative path.

I added resolve to convert relative to absolute path. 
(Not sure it was correct place just check, it works fine after changing in my machine Win_x64 for both chrome and window mode)