### PR TITLE
Removed WebView2Loader.dll from dependencies

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -24,7 +24,7 @@ module.exports = {
         x64: "neutralino-win_x64.exe"
       }
     },
-    dependencies: ["WebView2Loader.dll"]
+    dependencies: []
   },
   misc: {
     hotReloadLibPatchRegex: /(<script.*src=")(.*neutralino.js)(".*><\/script>)/g,


### PR DESCRIPTION
This PR follows [my other one](https://github.com/neutralinojs/neutralinojs/pull/1109) in [neutralinojs](https://github.com/neutralinojs/neutralinojs) that embeds WebView2Loader lib statically in Windows build.
WebView2Loader.dll won't be copied to dist folder anymore...