### PR TITLE
Use ipv4 loopback address

### DIFF
--- a/src/modules/websocket.js
+++ b/src/modules/websocket.js
@@ -18,7 +18,7 @@ module.exports.start = (options = {}) => {
         return;
     }
 
-    ws = new WS(`ws://localhost:${authInfo.port}?extensionId=js.neutralino.devtools`);
+    ws = new WS(`ws://127.0.0.1:${authInfo.port}?extensionId=js.neutralino.devtools`);
 
     ws.onerror = () => {
         retryLater(options);


### PR DESCRIPTION
Because some OSes, especially windows, tend to use the ipv6 version of the loopback address (::1), which does not work with the neutralino server, and some versions of NodeJS (>= 18) do resolve localhost addresses using the hosts config of the OS.

In response to the issue #208 