### PR TITLE
Fix behavior with vite's dev server

### DIFF
--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -127,7 +127,7 @@ module.exports.waitForFrontendLibApp = async () => {
     }, 500);
 
     try {
-        await tpu.waitUntilUsed(port, 200, 10000);
+        await tpu.waitUntilUsedOnHost(port, "localhost", 200, 10000);
     }
     catch(e) {
         utils.error(`Timeout exceeded while waiting till local TCP port: ${port}`);


### PR DESCRIPTION
Issue: https://github.com/neutralinojs/neutralinojs-cli/commit/18a2fed5ffcee2e5d43cbded40b5e61c971a75aa seems to have made it impossible for me to use frontend lib development with Vite. Even though port 5173 is connected, it just says "application will be launched when .. is ready" and eventually gives up.
Solution: Check `localhost` instead. The concept works in my tests with the library.