### PR TITLE
Don't kill the process when a command isn't found

### DIFF
--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -88,11 +88,11 @@ module.exports.cleanup = () => {
 
 
 module.exports.runCommand = (commandKey) => {
-    return new Promise((resolve, reject) => {
-        let configObj = config.get();
-        let frontendLib = configObj.cli?.frontendLibrary;
+    let configObj = config.get();
+    let frontendLib = configObj.cli?.frontendLibrary;
 
-        if(frontendLib?.projectPath && frontendLib?.[commandKey]) {
+    if(frontendLib?.projectPath && frontendLib?.[commandKey]) {
+        return new Promise((resolve, reject) => {
             let projectPath = utils.trimPath(frontendLib.projectPath);
             let cmd = frontendLib[commandKey];
 
@@ -102,8 +102,8 @@ module.exports.runCommand = (commandKey) => {
                 utils.log(`${commandKey} completed with exit code: ${code}`);
                 resolve();
             });
-        }
-    });
+        });
+    }
 }
 
 module.exports.containsFrontendLibApp = () => {


### PR DESCRIPTION
So the way Node works is it ends the process successfully when nothing is currently running. Even if the main thread is awaiting a promise, if no work is being done, it ends the process.
We have it currently set up so that we await frontend commands. However, if the command isn't found, we never `resolve` or `reject` it. We just return from the Promise, leaving it hanging. This makes Node exit, which heavily confused me.
This makes it so that it doesn't return a Promise unless it finds the command. This lets it just continue on if the command isn't set up.

If this is merged, this will fix a bug that's blocking me from building my app.