### PR TITLE
removing optional chaining

### DIFF
--- a/src/modules/filewatcher.js
+++ b/src/modules/filewatcher.js
@@ -27,7 +27,7 @@ function startFileWatcher() {
         '.*.log$'
     ];
 
-    if(configObj?.cli?.autoReloadExclude) {
+    if (configObj && configObj.cli && configObj.cli.autoReloadExclude) {
         exclude.push(configObj.cli.autoReloadExclude);
     }
     let watcherOptions = {

--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -16,10 +16,10 @@ async function makeClientLibUrl(port) {
     let configObj = config.get();
     let resourcesPath = configObj.cli.resourcesPath.replace(/^\//, '');
     let files = await recursive(resourcesPath);
-    let clientLib = files
-        .find((file) => /neutralino\.js$/.test(file))
-        ?.replace(/\\/g, '/'); //Fix path on windows;
-
+    let clientLib = files.find((file) => /neutralino\.js$/.test(file));
+    if (clientLib) {
+        clientLib = clientLib.replace(/\\/g, '/'); // Fix path on Windows
+    }
     let url = `http://localhost:${port}`;
 
     if(clientLib) {
@@ -89,9 +89,9 @@ module.exports.cleanup = () => {
 
 module.exports.runCommand = (commandKey) => {
     let configObj = config.get();
-    let frontendLib = configObj.cli?.frontendLibrary;
+    let frontendLib = configObj.cli ? configObj.cli.frontendLibrary : undefined;
 
-    if(frontendLib?.projectPath && frontendLib?.[commandKey]) {
+    if (frontendLib && frontendLib.projectPath && frontendLib[commandKey]) {
         return new Promise((resolve, reject) => {
             let projectPath = utils.trimPath(frontendLib.projectPath);
             let cmd = frontendLib[commandKey];
@@ -108,12 +108,12 @@ module.exports.runCommand = (commandKey) => {
 
 module.exports.containsFrontendLibApp = () => {
     let configObj = config.get();
-    return !!configObj.cli?.frontendLibrary;
+    return !!(configObj.cli && configObj.cli.frontendLibrary);
 }
 
 module.exports.waitForFrontendLibApp = async () => {
     let configObj = config.get();
-    let devUrlString = configObj.cli?.frontendLibrary?.devUrl;
+    let devUrlString = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.devUrl : undefined;
     let url = new URL(devUrlString);
     let portString = url.port;
     let port = portString ? Number.parseInt(portString) : getPortByProtocol(url.protocol)

--- a/src/plugins/pluginloader.js
+++ b/src/plugins/pluginloader.js
@@ -159,7 +159,7 @@ module.exports.removeTest = (pluginPath, uninstallSuccessCallback) => {
       pluginName = pluginPath;
     }
 
-    if (!pluginName && (!statsObj?.isDirectory() || !fs.existsSync(pluginPath))) {
+    if (!pluginName && (!statsObj || !statsObj.isDirectory() || !fs.existsSync(pluginPath))) {
       utils.error(`${pluginPath} is not a valid file path`);
 
       process.exit(1);

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,7 +39,7 @@ let warn = (message) => {
 }
 
 let trimPath = (path) => {
-    return path?.replace(/^\//, '');
+    return path ? path.replace(/^\//, ''): path;
 }
 
 let clearCache = () => {


### PR DESCRIPTION
Resolves: neutralinojs/neutralino.js#71

This PR removes optional chaining from the codebase as our current code does not support old version of node.

Alternatively, we could use traspilers to resolve this issue while maintaining out modern codebase 