### PR TITLE
remove existing build and bin before using again

### DIFF
--- a/spec/help.spec.js
+++ b/spec/help.spec.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const runner = require('./runner');
+
+describe('Run misc neu commands', () => {
+    before(() => {
+        runner.run('neu create test-app');
+        process.chdir('test-app');
+    });
+    describe('Test neu --help command', () => {
+        it('returns output of neu --help', async() => {
+            let output = runner.run('neu --help');
+
+            assert.equal(output.error, null);
+            assert.equal(output.status, 0);
+            assert.ok(typeof output.data == 'string');
+            assert.ok(output.data.includes('Usage: neu [options] [command]'));
+        });
+    });
+    after(() => {
+        process.chdir('..');
+        runner.cleanup();
+    });
+});

--- a/spec/help.spec.js
+++ b/spec/help.spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const runner = require('./runner');
 
-describe('Run misc neu commands', () => {
+describe('Run neu help command', () => {
     before(() => {
         runner.run('neu create test-app');
         process.chdir('test-app');

--- a/spec/version.spec.js
+++ b/spec/version.spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const runner = require('./runner');
 
-describe('Run misc neu commands', () => {
+describe('Run neu version command', () => {
     before(() => {
         runner.run('neu create test-app');
         process.chdir('test-app');

--- a/spec/version.spec.js
+++ b/spec/version.spec.js
@@ -6,16 +6,6 @@ describe('Run misc neu commands', () => {
         runner.run('neu create test-app');
         process.chdir('test-app');
     });
-    describe('Test neu --help command', () => {
-        it('returns output of neu --help', async() => {
-            let output = runner.run('neu --help');
-
-            assert.equal(output.error, null);
-            assert.equal(output.status, 0);
-            assert.ok(typeof output.data == 'string');
-            assert.ok(output.data.includes('Usage: neu [options] [command]'));
-        });
-    });
     describe('Test neu version command', () => {
         it('returns output of neu version --help', async() => {
             let output = runner.run('neu version --help');

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -9,6 +9,7 @@ module.exports.register = (program) => {
         .option('--copy-storage')
         .action(async (command) => {
             utils.checkCurrentProject();
+            utils.removeExistingFiles("./dist")
             utils.log('Bundling app...');
             await bundler.bundleApp(command.release, command.copyStorage);
             utils.showArt();

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -8,6 +8,7 @@ module.exports.register = (program) => {
         .option('-l, --latest')
         .action(async (command) => {
             utils.checkCurrentProject();
+            utils.removeExistingFiles("./bin")
             await downloader.downloadAndUpdateBinaries(command.latest);
             await downloader.downloadAndUpdateClient(command.latest);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,6 +50,13 @@ let getVersionTag = (version) => {
     return version != 'nightly' ? 'v' + version : version;
 }
 
+let removeExistingFiles = (path) => {
+    if(fse.existsSync(path)){
+        log("Removing existing files...")
+        fse.rmSync(path, { recursive: true });
+    }
+}
+
 module.exports = {
     error,
     isNeutralinojsProject,
@@ -60,5 +67,6 @@ module.exports = {
     warn,
     trimPath,
     clearCache,
-    getVersionTag
+    getVersionTag,
+    removeExistingFiles
 }


### PR DESCRIPTION
This PR deletes existing build files while using `neu build` command and binaries while using `neu update` command.
Also Separates **misc.spec.js** into **help.spec.js** and **version.spec.js** which increases GitHub Actions time by little bit (1-2s) but maintains consistency

Fixes #224 
Solves https://discord.com/channels/869948661084340265/869948661906436128/1212303298892140564