### PR TITLE
fix: Use configured host for waiting

### DIFF
--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -127,7 +127,7 @@ module.exports.waitForFrontendLibApp = async () => {
     }, 500);
 
     try {
-        await tpu.waitUntilUsedOnHost(port, 'localhost', 200, 10000);
+        await tpu.waitUntilUsedOnHost(port, url.hostname, 200, 10000);
     }
     catch(e) {
         utils.error(`Timeout exceeded while waiting till local TCP port: ${port}`);


### PR DESCRIPTION
The change fixes an error that forces the use of the IPv6 protocol when querying the `cli.frontendLibrary.devUrl`.
If the IPv6 protocol cannot be disabled on the developer system, you can now work around this by using `"devUrl": "http://127.0.0.1:<port>"`. This was not possible before.
Please include the fix in your code. Thank you very much!

