### PR TITLE
feat: Add "cli.frontendLibrary.dontStartBrowser" configuration variable.

### DIFF
--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -97,7 +97,12 @@ module.exports.runCommand = (commandKey) => {
             let cmd = frontendLib[commandKey];
 
             utils.log(`Running ${commandKey}: ${cmd}...`);
-            const proc = spawnCommand(cmd, { stdio: 'inherit', cwd: projectPath });
+            let env = { ...process.env };
+
+            if (frontendLib.dontStartBrowser === undefined || frontendLib.dontStartBrowser) {
+                env.BROWSER = "none";
+            }
+            const proc = spawnCommand(cmd, { stdio: 'inherit', cwd: projectPath, env: env });
             proc.on('exit', (code) => {
                 utils.log(`${commandKey} completed with exit code: ${code}`);
                 resolve();


### PR DESCRIPTION
This feature adds a configuration variable that can be used to pass the `BROWSER=none` environment variable to the `devCommand` directly from the code. The prefix can thus be shortened from the command. This supports the cross-platform compatibility of a project without the need to use external libraries such as `cross-env`. 
As the process environment for the `devCommand` is copied and then modified, global variables are still permitted and the current environment of the process is not affected.
The feature is also backwards compatible, as a process does not mind that the same variable is set twice.

The behavior of the variable is:

- `cli.frontendLibrary.dontStartBrowser = unavailable => BROWSER=none will be added to the devCommand call`
- `cli.frontendLibrary.dontStartBrowser = true        => BROWSER=none will be added to the devCommand call`
- `cli.frontendLibrary.dontStartBrowser = false       => nothing will be added to the devCommand call`