### PR TITLE
Dynamic build paths

### DIFF
--- a/spec/build.spec.js
+++ b/spec/build.spec.js
@@ -24,7 +24,7 @@ describe('Run neu build command and its options', () => {
             assert.equal(output.error, null);
             assert.equal(output.status, 0);
             assert.ok(typeof output.data == 'string');
-            assert.ok(output.data.includes('Application package was generated at the ./dist directory!'));
+            assert.ok(output.data.includes('Application package was generated at the dist directory!'));
             assert.ok(binaries.includes('resources.neu') &&
                 binaries.includes('test-app-linux_arm64') &&
                 binaries.includes('test-app-linux_armhf') &&
@@ -41,7 +41,7 @@ describe('Run neu build command and its options', () => {
             assert.equal(output.error, null);
             assert.equal(output.status, 0);
             assert.ok(typeof output.data == 'string');
-            assert.ok(output.data.includes('Application package was generated at the ./dist directory!') &&
+            assert.ok(output.data.includes('Application package was generated at the dist directory!') &&
                 output.data.includes('Making app bundle ZIP file'));
             assert.ok(applicationBundle.includes('test-app-release.zip'));
         });
@@ -53,7 +53,7 @@ describe('Run neu build command and its options', () => {
             assert.equal(output.error, null);
             assert.equal(output.status, 0);
             assert.ok(typeof output.data == 'string');
-            assert.ok(output.data.includes('Application package was generated at the ./dist directory!') &&
+            assert.ok(output.data.includes('Application package was generated at the dist directory!') &&
                 output.data.includes('Copying binaries') &&
                 output.data.includes('Copying storage data'));
             assert.ok(storageSnapshot.includes('.storage'));

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,5 +1,6 @@
 const utils = require('../utils');
 const bundler = require('../modules/bundler');
+const config = require('../modules/config');
 
 module.exports.register = (program) => {
     program
@@ -9,12 +10,14 @@ module.exports.register = (program) => {
         .option('--copy-storage')
         .action(async (command) => {
             utils.checkCurrentProject();
+            const configObj = config.get()
             utils.log('Removing current build...');
-            utils.clearDirectory('dist');
+            const buildDir = configObj.distributionPath ? utils.trimPath(configObj.distributionPath) : 'dist';
+            utils.clearDirectory(buildDir);
             utils.log('Bundling app...');
             await bundler.bundleApp(command.release, command.copyStorage);
             utils.showArt();
-            utils.log('Application package was generated at the ./dist directory!');
+            utils.log(`Application package was generated at the ${buildDir} directory!`);
             utils.log('Distribution guide: https://neutralino.js.org/docs/distribution/overview');
         });
 }


### PR DESCRIPTION
closes #178 
Uses `dist` folder as default build directory
updated `build.spec` file.
pr for updated docs has been made [#306](https://github.com/neutralinojs/neutralinojs.github.io/pull/306)