### PR TITLE
[Fix] Resolve issue involving improper handling of cases where 'icon' variable is undefined when 'neu' CLI attempts to create an ASAR file using the 'bundler.js' module

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -6,6 +6,7 @@ const config = require('./config');
 const constants = require('../constants');
 const frontendlib = require('./frontendlib');
 const utils = require('../utils');
+const path = require("path");
 
 async function createAsarFile() {
     utils.log(`Generating ${constants.files.resourceFile}...`);
@@ -14,7 +15,7 @@ async function createAsarFile() {
     const extensionsDir = utils.trimPath(configObj.cli.extensionsPath);
     const clientLibrary = configObj.cli.clientLibrary ? utils.trimPath(configObj.cli.clientLibrary)
                             : null;
-    const icon = utils.trimPath(configObj.modes.window.icon);
+    let icon = utils.trimPath(configObj.modes.window.icon);
     const binaryName = configObj.cli.binaryName;
     const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
 
@@ -34,17 +35,26 @@ async function createAsarFile() {
         }
     }
 
+    let iconDestinationFilePath = "";
+
     // This check prevents the 'neu' CLI tool from failing to build an application properly if the
     // 'icon' variable is undefined.
     // If it is mandatory for 'icon' to be defined, then the documentation should mention this as it
     // currently does not mention anything regarding this.
-    if (icon != undefined)
+    if (icon == undefined)
     {
-        // This method throws an error if 'icon' is undefined, resulting in the following error message
-        // being logged to the console:
-        // neu: ERRR Error: ENOENT: no such file or directory, stat 'C:\Users\John\Neutralino-App-Project\undefined'
-        await fse.copy(`./${icon}`, `.tmp/${icon}`, {overwrite: true});
+        icon = utils.getNeutralinoIconFilePath();
+
+        iconDestinationFilePath = `.tmp/icon.png`;
     }
+    else
+    {
+        icon = `./${resourcesDir}${icon}`;
+
+        iconDestinationFilePath = `.tmp/${icon.replace(`./${resourcesDir}`, "")}`;
+    }
+
+    await fse.copy(icon, iconDestinationFilePath, {overwrite: true});
 
     await asar.createPackage('.tmp', `${buildDir}/${binaryName}/${constants.files.resourceFile}`);
 }

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -33,7 +33,18 @@ async function createAsarFile() {
             fse.removeSync(`.tmp/${typesFile}`);
         }
     }
-    await fse.copy(`./${icon}`, `.tmp/${icon}`, {overwrite: true});
+
+    // This check prevents the 'neu' CLI tool from failing to build an application properly if the
+    // 'icon' variable is undefined.
+    // If it is mandatory for 'icon' to be defined, then the documentation should mention this as it
+    // currently does not mention anything regarding this.
+    if (icon != undefined)
+    {
+        // This method throws an error if 'icon' is undefined, resulting in the following error message
+        // being logged to the console:
+        // neu: ERRR Error: ENOENT: no such file or directory, stat 'C:\Users\John\Neutralino-App-Project\undefined'
+        await fse.copy(`./${icon}`, `.tmp/${icon}`, {overwrite: true});
+    }
 
     await asar.createPackage('.tmp', `${buildDir}/${binaryName}/${constants.files.resourceFile}`);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ const process = require('process');
 const figlet = require('figlet');
 const chalk = require('chalk');
 const constants = require('./constants');
+const pathModule = require("path");
 const CONFIG_FILE = constants.files.configFile;
 
 let error = (message) => {
@@ -38,6 +39,17 @@ let warn = (message) => {
     console.warn(`neu: ${chalk.bgYellow.black('WARN')} ${message}`);
 }
 
+/**
+ * Removes the first character in the ``path`` argument if it is a ``/`` character.
+ * 
+ * ### Example
+ * Initial value of ``path`` argument: ``/usr/bin``
+ * 
+ * Returned value: ``usr/bin``
+ * 
+ * @param {string} path 
+ * @returns 
+ */
 let trimPath = (path) => {
     return path ? path.replace(/^\//, ''): path;
 }
@@ -50,6 +62,20 @@ let getVersionTag = (version) => {
     return version != 'nightly' ? 'v' + version : version;
 }
 
+let getNeutralinoIconFilePath = () =>
+{
+    // Note: This code might have to be adapted if the location of this file changes (i.e. it is
+    // placed into another folder at a different path).
+    let srcFolderPath = __dirname;
+    let neutralinoIconFilePath = pathModule.resolve(
+        srcFolderPath,
+        "..",
+        "images",
+        "logo.png"
+    );
+    return neutralinoIconFilePath;
+}
+
 module.exports = {
     error,
     isNeutralinojsProject,
@@ -60,5 +86,6 @@ module.exports = {
     warn,
     trimPath,
     getVersionTag,
-    clearDirectory
+    clearDirectory,
+    getNeutralinoIconFilePath
 }


### PR DESCRIPTION
This PR aims to resolve the issue mentioned in its title.

This issue causes the ``neu`` CLI program's ``build`` subcommand to fail to build a NeutralinoJS application properly (no ``dist`` containing the generated binaries was created and only a ``.tmp`` folder remained after the CLI tool reportedly claimed to have successfully finished building the said application).