### PR TITLE
Adding a support system for proxy setting to download

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -6,9 +6,9 @@ module.exports.register = (program) => {
         .command('create <binaryName>')
         .description('creates an app based on template (neutralinojs/neutralinojs-minimal by default)')
         .option('-t, --template [template]')
+        .option('-p, --proxy [proxy]', 'specify proxy URL for downloading templates')
         .action(async (binaryName, command) => {
-            await creator.createApp(binaryName, command.template);
+            await creator.createApp(binaryName, command.template, command.proxy);
             utils.showArt();
         });
 }
-

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -6,13 +6,13 @@ module.exports.register = (program) => {
         .command('update')
         .description('updates neutralinojs binaries, client library, and TypeScript definitions')
         .option('-l, --latest')
+        .option('-p, --proxy [proxy]', 'specify proxy URL for downloading resources')
         .action(async (command) => {
             utils.checkCurrentProject();
-            await downloader.downloadAndUpdateBinaries(command.latest);
-            await downloader.downloadAndUpdateClient(command.latest);
+            await downloader.downloadAndUpdateBinaries(command.latest, command.proxy);
+            await downloader.downloadAndUpdateClient(command.latest, command.proxy);
 
             utils.showArt();
             utils.log('Run "neu version" to see installed version details.');
         });
 }
-

--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -6,12 +6,12 @@ const downloader = require('./downloader');
 const frontendlib = require('../modules/frontendlib');
 const utils = require('../utils');
 
-module.exports.createApp = async (binaryName, template) => {
+module.exports.createApp = async (binaryName, template, proxy) => {
     if (fs.existsSync(`./${binaryName}`)) {
         utils.error('App name already exists');
         process.exit(1);
     }
-    if(!template) {
+    if (!template) {
         template = 'neutralinojs/neutralinojs-minimal';
     }
     utils.log(`Downloading ${template} template to ${binaryName} directory...`);
@@ -20,13 +20,13 @@ module.exports.createApp = async (binaryName, template) => {
     process.chdir(binaryName); // Change the path context for the following methods
 
     try {
-        await downloader.downloadTemplate(template);
-        await downloader.downloadAndUpdateBinaries();
-        await downloader.downloadAndUpdateClient();
-    }
-    catch(err) {
-        utils.error('Unable to download resources from internet.' +
-                    ' Please check your internet connection and template URLs.');
+        // Pass proxy information to downloader functions
+        await downloader.downloadTemplate(template, proxy);
+        await downloader.downloadAndUpdateBinaries(false, proxy);
+        await downloader.downloadAndUpdateClient(false, proxy);
+    } catch (err) {
+        utils.error('Unable to download resources from the internet.' +
+            ' Please check your internet connection and template URLs.');
         fse.removeSync(`../${binaryName}`);
         process.exit(1);
     }
@@ -34,7 +34,7 @@ module.exports.createApp = async (binaryName, template) => {
     config.update('cli.binaryName', binaryName);
     config.update('modes.window.title', binaryName);
 
-    if(frontendlib.containsFrontendLibApp()) {
+    if (frontendlib.containsFrontendLibApp()) {
         await frontendlib.runCommand('initCommand');
     }
 


### PR DESCRIPTION
### **Description:**
- This pull request introduces proxy support for the neu create and neu update commands in the NeutralinoJS CLI tool. Proxy support enables users to create and update NeutralinoJS applications seamlessly while operating behind a proxy server.

### **Related Issues:**
https://github.com/neutralinojs/neutralinojs-cli/issues/198 -> **"neu create fail behind a proxy"** 

### **Changes Made:**
- Added Proxy Support for neu create Command:

- Modified the create command in commands/create.js to accept a proxy option (-p, --proxy [proxy]).
Users can now specify a proxy URL when creating a new NeutralinoJS application.
Added Proxy Support for neu update Command:

- Modified the update command in commands/update.js to accept a proxy option (-p, --proxy [proxy]).
Users can now specify a proxy URL when updating NeutralinoJS resources.
Updated modules/downloader.js:

- Modified the downloadBinariesFromRelease and downloadClientFromRelease functions to utilize proxy settings when downloading resources.

### **Updated Dependencies:**
- Added necessary dependencies (follow-redirects and decompress) to support proxy settings.

### **How to Test:**
- Ensure you have the latest version of the NeutralinoJS CLI tool installed.
Create a new NeutralinoJS application using the neu create command with the -p or --proxy option, providing a valid proxy URL.
- Update an existing NeutralinoJS application using the neu update command with the -p or --proxy option, providing a valid proxy URL.
- Verify that the application is created or updated successfully, and the proxy settings are applied during resource download.

**Additional Notes:**
- Proxy support enhances the usability of the NeutralinoJS CLI tool for users operating behind a proxy server.
- This feature improves accessibility and ensures a seamless experience for developers working in restricted network environments.