### PR TITLE
feat: Check Template Validity before downloading

### DIFF
--- a/bin/neu.js
+++ b/bin/neu.js
@@ -7,8 +7,6 @@ const utils = require('../src/utils');
 const program = new Command();
 neu.bootstrap(program);
 
-console.log("hello world")
-
 program.addHelpText('beforeAll', utils.getFiglet());
 program.parse(process.argv);
 

--- a/bin/neu.js
+++ b/bin/neu.js
@@ -7,6 +7,8 @@ const utils = require('../src/utils');
 const program = new Command();
 neu.bootstrap(program);
 
+console.log("hello world")
+
 program.addHelpText('beforeAll', utils.getFiglet());
 program.parse(process.argv);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,8 @@ module.exports = {
     binariesUrl:"https://github.com/neutralinojs/neutralinojs/releases/download/{tag}/neutralinojs-{tag}.zip",
     clientUrlPrefix: "https://github.com/neutralinojs/neutralino.js/releases/download/{tag}/neutralino.",
     templateUrl: "https://github.com/{template}/archive/main.zip",
-    releasesApiUrl: "https://api.github.com/repos/neutralinojs/{repo}/releases/latest"
+    releasesApiUrl: "https://api.github.com/repos/neutralinojs/{repo}/releases/latest",
+    templateCheckUrl: "https://api.github.com/repos/{template}/contents/neutralino.config.json"
   },
   files: {
     configFile: "neutralino.config.json",

--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -14,6 +14,15 @@ module.exports.createApp = async (binaryName, template) => {
     if(!template) {
         template = 'neutralinojs/neutralinojs-minimal';
     }
+
+    utils.log(`Checking if ${template} is a valid template...`);
+
+    const isValidTemplate = await downloader.checkIfTemplateValid(template)
+    if( !isValidTemplate ) {
+        utils.error(`${template} is not a valid template.`);
+        process.exit(1);
+    }
+
     utils.log(`Downloading ${template} template to ${binaryName} directory...`);
 
     fs.mkdirSync(binaryName, { recursive: true });

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -16,13 +16,13 @@ let getLatestVersion = (repo) => {
         }
 
         let opt = {
-            headers: {'User-Agent': 'Neutralinojs CLI'}
+            headers: { 'User-Agent': 'Neutralinojs CLI' }
         };
         https.get(constants.remote.releasesApiUrl.replace('{repo}', repo), opt, function (response) {
             let body = '';
             response.on('data', (data) => body += data);
             response.on('end', () => {
-                if(response.statusCode != 200) {
+                if (response.statusCode != 200) {
                     return fallback();
                 }
                 let apiRes = JSON.parse(body);
@@ -47,7 +47,7 @@ let getBinaryDownloadUrl = async (latest) => {
     const configObj = config.get();
     let version = configObj.cli.binaryVersion;
 
-    if(!version || latest) {
+    if (!version || latest) {
         version = await getLatestVersion('neutralinojs');
         config.update('cli.binaryVersion', version);
     }
@@ -59,8 +59,8 @@ let getClientDownloadUrl = async (latest, types = false) => {
     const configObj = config.get();
     let version = configObj.cli.clientVersion;
 
-    if(!version || latest) {
-        if(cachedLatestClientVersion) {
+    if (!version || latest) {
+        if (cachedLatestClientVersion) {
             version = cachedLatestClientVersion;
         }
         else {
@@ -72,7 +72,7 @@ let getClientDownloadUrl = async (latest, types = false) => {
 
     let scriptUrl = constants.remote.clientUrlPrefix + (types ? 'd.ts' : getScriptExtension());
     return scriptUrl
-            .replace(/{tag}/g, utils.getVersionTag(version));
+        .replace(/{tag}/g, utils.getVersionTag(version));
 }
 
 let getTypesDownloadUrl = (latest) => {
@@ -100,7 +100,7 @@ let downloadBinariesFromRelease = (latest) => {
                             .catch((e) => reject(e));
                     });
                 });
-        });
+            });
     });
 }
 
@@ -166,29 +166,29 @@ module.exports.downloadTemplate = (template) => {
 module.exports.downloadAndUpdateBinaries = async (latest = false) => {
     await downloadBinariesFromRelease(latest);
     utils.log('Finalizing and cleaning temp. files.');
-    if(!fse.existsSync('bin'))
+    if (!fse.existsSync('bin'))
         fse.mkdirSync('bin');
 
-    for(let platform in constants.files.binaries) {
-        for(let arch in constants.files.binaries[platform]) {
+    for (let platform in constants.files.binaries) {
+        for (let arch in constants.files.binaries[platform]) {
             let binaryFile = constants.files.binaries[platform][arch];
-            if(fse.existsSync(`.tmp/${binaryFile}`)) {
+            if (fse.existsSync(`.tmp/${binaryFile}`)) {
                 fse.copySync(`.tmp/${binaryFile}`, `bin/${binaryFile}`);
             }
         }
     }
 
-    for(let dependency of constants.files.dependencies) {
-        fse.copySync(`.tmp/${dependency}`,`bin/${dependency}`);
+    for (let dependency of constants.files.dependencies) {
+        fse.copySync(`.tmp/${dependency}`, `bin/${dependency}`);
     }
     utils.clearDirectory('.tmp');
 }
 
 module.exports.downloadAndUpdateClient = async (latest = false) => {
     const configObj = config.get();
-    if(!configObj.cli.clientLibrary) {
+    if (!configObj.cli.clientLibrary) {
         utils.log(`neu CLI won't download the client library --` +
-                    ` download @neutralinojs/lib from your Node package manager.`);
+            ` download @neutralinojs/lib from your Node package manager.`);
         return;
     }
     const clientLibrary = utils.trimPath(configObj.cli.clientLibrary);
@@ -196,9 +196,48 @@ module.exports.downloadAndUpdateClient = async (latest = false) => {
     await downloadTypesFromRelease(latest);
     utils.log('Finalizing and cleaning temp. files...');
     fse.copySync(`.tmp/${constants.files.clientLibraryPrefix + getScriptExtension()}`
-            , `./${clientLibrary}`);
+        , `./${clientLibrary}`);
     fse.copySync(`.tmp/neutralino.d.ts`
-            , `./${clientLibrary.replace(/[.][a-z]*$/, '.d.ts')}`);
+        , `./${clientLibrary.replace(/[.][a-z]*$/, '.d.ts')}`);
     utils.clearDirectory('.tmp');
 }
 
+module.exports.checkIfTemplateValid = (template) => {
+    return new Promise((resolve) => {
+        console.log(constants.remote.templateCheckUrl.replace('{template}', template));
+        https.get(constants.remote.templateCheckUrl.replace('{template}', template), {
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28',
+                "Accept": "application/vnd.github+json",
+                'User-Agent': 'Neutralinojs CLI'
+            }
+        }, function (response) {
+            let data = '';
+            
+            response.on('data', (chunk) => {
+                data += chunk;
+            });
+            
+            response.on('end', () => {
+                try {
+                    const jsonData = JSON.parse(data);
+                    if(jsonData.message !== 'Not Found') {
+                        resolve(true);
+                    }
+                    else{
+                        resolve(false);
+                    }
+                } catch (error) {
+                    utils.warn('Unable to check the template validity.');
+                    resolve(true);
+                }
+            });
+            
+            response.on('error', () => {
+                utils.warn('Unable to check the template validity.');
+                resolve(true);
+            });
+        });
+    });
+    
+}

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -223,7 +223,7 @@ module.exports.checkIfTemplateValid = (template) => {
                     if(jsonData.message === 'Not Found') {
                         resolve(false);
                     }
-                    else if(jsonData.message.includes("API rate limit exceeded")) {
+                    else if(jsonData.message && jsonData.message.includes("API rate limit exceeded")) {
                         utils.warn('Unable to check the template validity due to API rate limits.');
                         resolve(true);
                     }

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -206,8 +206,6 @@ module.exports.checkIfTemplateValid = (template) => {
     return new Promise((resolve) => {
         https.get(constants.remote.templateCheckUrl.replace('{template}', template), {
             headers: {
-                'X-GitHub-Api-Version': '2022-11-28',
-                "Accept": "application/vnd.github+json",
                 'User-Agent': 'Neutralinojs CLI'
             }
         }, function (response) {

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -204,7 +204,6 @@ module.exports.downloadAndUpdateClient = async (latest = false) => {
 
 module.exports.checkIfTemplateValid = (template) => {
     return new Promise((resolve) => {
-        console.log(constants.remote.templateCheckUrl.replace('{template}', template));
         https.get(constants.remote.templateCheckUrl.replace('{template}', template), {
             headers: {
                 'X-GitHub-Api-Version': '2022-11-28',
@@ -221,11 +220,15 @@ module.exports.checkIfTemplateValid = (template) => {
             response.on('end', () => {
                 try {
                     const jsonData = JSON.parse(data);
-                    if(jsonData.message !== 'Not Found') {
+                    if(jsonData.message === 'Not Found') {
+                        resolve(false);
+                    }
+                    else if(jsonData.message.includes("API rate limit exceeded")) {
+                        utils.warn('Unable to check the template validity due to API rate limits.');
                         resolve(true);
                     }
                     else{
-                        resolve(false);
+                        resolve(true);
                     }
                 } catch (error) {
                     utils.warn('Unable to check the template validity.');


### PR DESCRIPTION
right now we dont have a check before downloading the zip to determine if a template is a valid template or not, and the app exits with error not telling the actual issue, I have added a check before downloading the template if `neutralino.config.json` file exists in root directory of the template repository or not to determine if the template is valid or not.

Previous Error
![image](https://github.com/neutralinojs/neutralinojs-cli/assets/119971154/6298cf64-ba08-4835-8c80-1e73581f948c)

Current Error
![image](https://github.com/neutralinojs/neutralinojs-cli/assets/119971154/835b5fdf-ae19-457a-acaa-b4a42489b876)
