### PR TITLE
Making clearing the current build in the `neu build` command optional

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -8,12 +8,15 @@ module.exports.register = (program) => {
         .description('builds binaries for all supported platforms and resources.neu file')
         .option('-r, --release')
         .option('--copy-storage')
+        .option('--clear-build')
         .action(async (command) => {
             utils.checkCurrentProject();
             const configObj = config.get()
-            utils.log('Removing current build...');
             const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
-            utils.clearDirectory(buildDir);
+            if(command.clearBuild) {
+                utils.log('Removing current build...');
+                utils.clearDirectory(buildDir);
+            }
             utils.log('Bundling app...');
             await bundler.bundleApp(command.release, command.copyStorage);
             utils.showArt();

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -8,13 +8,13 @@ module.exports.register = (program) => {
         .description('builds binaries for all supported platforms and resources.neu file')
         .option('-r, --release')
         .option('--copy-storage')
-        .option('--clear-build')
+        .option('--clean')
         .action(async (command) => {
             utils.checkCurrentProject();
             const configObj = config.get()
             const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
-            if(command.clearBuild) {
-                utils.log('Removing current build...');
+            if(command.clean) {
+                utils.log(`Cleaning current build files from ${buildDir}...`);
                 utils.clearDirectory(buildDir);
             }
             utils.log('Bundling app...');


### PR DESCRIPTION
Resolves: #258 

This PR makes it optional to remove the current build in the `neu build` command 

![ss](https://github.com/neutralinojs/neutralinojs-cli/assets/119438857/2b8d1ae5-d9a0-42ce-b655-58d2153f7d78)
