### PR TITLE
Add configurable timeout

### DIFF
--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -114,7 +114,7 @@ module.exports.containsFrontendLibApp = () => {
 module.exports.waitForFrontendLibApp = async () => {
     let configObj = config.get();
     let devUrlString = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.devUrl : undefined;
-    let timeout = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.timeout : 10000;
+    let timeout = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.waitTimeout : 10000;
     let url = new URL(devUrlString);
     let portString = url.port;
     let port = portString ? Number.parseInt(portString) : getPortByProtocol(url.protocol)

--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -114,7 +114,7 @@ module.exports.containsFrontendLibApp = () => {
 module.exports.waitForFrontendLibApp = async () => {
     let configObj = config.get();
     let devUrlString = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.devUrl : undefined;
-    let timeout = Number.parseInt(configObj?.cli?.frontendLibrary?.timeout) || 10000;
+    let timeout = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.timeout : 10000;
     let url = new URL(devUrlString);
     let portString = url.port;
     let port = portString ? Number.parseInt(portString) : getPortByProtocol(url.protocol)

--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -114,6 +114,7 @@ module.exports.containsFrontendLibApp = () => {
 module.exports.waitForFrontendLibApp = async () => {
     let configObj = config.get();
     let devUrlString = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.devUrl : undefined;
+    let timeout = Number.parseInt(configObj?.cli?.frontendLibrary?.timeout) || 10000;
     let url = new URL(devUrlString);
     let portString = url.port;
     let port = portString ? Number.parseInt(portString) : getPortByProtocol(url.protocol)
@@ -124,10 +125,10 @@ module.exports.waitForFrontendLibApp = async () => {
 
     let inter = setInterval(() => {
         utils.log(`App will be launched when ${devUrlString} on port ${port} is ready...`);
-    }, 500);
+    }, 2500);
 
     try {
-        await tpu.waitUntilUsedOnHost(port, url.hostname, 200, 10000);
+        await tpu.waitUntilUsedOnHost(port, url.hostname, 200, timeout);
     }
     catch(e) {
         utils.error(`Timeout exceeded while waiting till local TCP port: ${port}`);


### PR DESCRIPTION
Some frontend libraries like react take quite a while to spin up their dev server.
On some lower-end machines, it may even take more than 10 seconds.
To avoid this issue, I have added a new property under `config.cli.frontendLibrary.timeout` which allows you to specify an amount of miliseconds to wait for the dev server to spin up, thus overriding the default of 10 seconds.
This modification does not break compatibility, as it will still use 10 seconds if the option is not specified.