### PR TITLE
Fix/resource busy rmdir

### DIFF
--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -36,7 +36,14 @@ module.exports.createApp = async (binaryName, template) => {
     catch(err) {
         utils.error('Unable to download resources from internet.' +
                     ' Please check your internet connection and template URLs.');
-        fse.removeSync(`../${binaryName}`);
+
+        const parentDirPath = path.resolve('..');
+        const binaryPath = path.resolve('.');
+        process.chdir(parentDirPath);
+        fse.removeSync(binaryPath)        
+        
+        utils.log(`Removed created directory. (${binaryName})`);
+        
         process.exit(1);
     }
 

--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -5,6 +5,7 @@ const config = require('../modules/config');
 const downloader = require('./downloader');
 const frontendlib = require('../modules/frontendlib');
 const utils = require('../utils');
+const path = require('path');
 
 module.exports.createApp = async (binaryName, template) => {
     if (fs.existsSync(`./${binaryName}`)) {


### PR DESCRIPTION
fixed `Error: EBUSY: resource busy or locked, rmdir '../node'` error while creating a neu app on Windows. 
This would leave a folder without removing the .tmp files from the folder.

Previous error
![image](https://github.com/neutralinojs/neutralinojs-cli/assets/119971154/28bbab9a-b2c8-47d3-b37d-cd6aaca2aecc)

Current Solution
![image](https://github.com/neutralinojs/neutralinojs-cli/assets/119971154/e638ca2a-9664-44b1-893d-ee4c92086194)
