### PR TITLE
Patch HTML file before starting dev server

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -17,6 +17,10 @@ module.exports.register = (program) => {
             let containsFrontendLibApp = frontendlib.containsFrontendLibApp();
             let argsOpt = "";
 
+            websocket.start({
+                frontendLibDev: containsFrontendLibApp
+            });
+            
             if(containsFrontendLibApp) {
                 frontendlib.runCommand('devCommand');
                 await frontendlib.waitForFrontendLibApp();
@@ -26,10 +30,6 @@ module.exports.register = (program) => {
                 argsOpt += "--neu-dev-auto-reload";
                 filewatcher.start();
             }
-
-            websocket.start({
-                frontendLibDev: containsFrontendLibApp
-            });
 
             // Add additional process ARGs that comes after --
             let parseStopIndex = process.argv.indexOf('--');


### PR DESCRIPTION
The dev server(frontend framework) is ran before the HTML file is patched with the new url of the globals file, resulting in: "Failed to load resource."
I'm not sure if I'm breaking anything by re-ordering the function invocation, but it seems to work for me.