### PR TITLE
Feat: support project runner

### DIFF
--- a/spec/.gitignore
+++ b/spec/.gitignore
@@ -133,5 +133,3 @@ dist
 .svelte-kit
 
 # End of https://www.toptal.com/developers/gitignore/api/node
-
-test-app

--- a/spec/.gitignore
+++ b/spec/.gitignore
@@ -133,3 +133,5 @@ dist
 .svelte-kit
 
 # End of https://www.toptal.com/developers/gitignore/api/node
+
+test-app

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -4,6 +4,7 @@ const runner = require('../modules/runner');
 const utils = require('../utils');
 const config = require('../modules/config');
 const frontendlib = require('../modules/frontendlib');
+const projectRunner = require('../modules/projectRunner');
 
 module.exports.register = (program) => {
     program
@@ -14,6 +15,17 @@ module.exports.register = (program) => {
         .action(async (command) => {
             utils.checkCurrentProject();
             let configObj = config.get();
+
+            if(configObj.cli && configObj.cli.projectRunner) {
+                try {
+                    await projectRunner.runApp();
+                    process.exit(0);
+                } catch (error) {
+                    utils.log(error);
+                    process.exit(1);
+                }
+            }
+
             let containsFrontendLibApp = frontendlib.containsFrontendLibApp();
             let argsOpt = "";
 

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -78,7 +78,7 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
         for (let platform in constants.files.binaries) {
             for (let arch in constants.files.binaries[platform]) {
                 let originalBinaryFile = constants.files.binaries[platform][arch];
-                let destinationBinaryFile = originalBinaryFile.replace('neutralino', binaryName);
+                let destinationBinaryFile = projectRunner.containsRunnerApp() ? originalBinaryFile : originalBinaryFile.replace('neutralino', binaryName);
                 if (fse.existsSync(`bin/${originalBinaryFile}`)) {
                     fse.copySync(`bin/${originalBinaryFile}`, `${buildDir}/${binaryName}/${destinationBinaryFile}`);
                 }

--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -4,6 +4,7 @@ const fse = require('fs-extra');
 const config = require('../modules/config');
 const downloader = require('./downloader');
 const frontendlib = require('../modules/frontendlib');
+const projectRunner = require('../modules/projectRunner');
 const utils = require('../utils');
 
 module.exports.createApp = async (binaryName, template) => {
@@ -45,6 +46,10 @@ module.exports.createApp = async (binaryName, template) => {
 
     if(frontendlib.containsFrontendLibApp()) {
         await frontendlib.runCommand('initCommand');
+    }
+
+    if(projectRunner.containsRunnerApp()) {
+        await projectRunner.runCommand('initCommand');
     }
 
     console.log('-------');

--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -99,7 +99,7 @@ module.exports.runCommand = (commandKey) => {
             utils.log(`Running ${commandKey}: ${cmd}...`);
             const proc = spawnCommand(cmd, { stdio: 'inherit', cwd: projectPath });
             proc.on('exit', (code) => {
-                utils.log(`${commandKey} completed with exit code: ${code}`);
+                utils.log(`FrontendLib: ${commandKey} completed with exit code: ${code}`);
                 resolve();
             });
         });

--- a/src/modules/projectRunner.js
+++ b/src/modules/projectRunner.js
@@ -3,7 +3,7 @@ const spawnCommand = require('spawn-command');
 const config = require('./config');
 const utils = require('../utils');
 
-module.exports.containsRunnerApp = async () => {
+module.exports.containsRunnerApp = () => {
   let configObj = config.get();
   return !!(configObj.cli && configObj.cli.projectRunner);
 }

--- a/src/modules/projectRunner.js
+++ b/src/modules/projectRunner.js
@@ -1,0 +1,50 @@
+const process = require('process');
+const spawnCommand = require('spawn-command');
+const config = require('./config');
+const utils = require('../utils');
+
+module.exports.containsRunnerApp = async () => {
+  let configObj = config.get();
+  return !!(configObj.cli && configObj.cli.projectRunner);
+}
+
+module.exports.runCommand = async (commandKey) => {
+  let configObj = config.get();
+  let projectRunner = configObj.cli ? configObj.cli.projectRunner : undefined;
+
+  if (projectRunner && projectRunner[commandKey]) {
+
+      return new Promise((resolve, _reject) => {
+          let cmd = projectRunner[commandKey];
+
+          utils.log(`Running ${commandKey}: ${cmd}...`);
+
+          const proc = spawnCommand(cmd, { stdio: 'inherit'});
+          proc.on('exit', (code) => {
+              utils.log(`Project Runner: ${commandKey} completed with exit code: ${code}`);
+              resolve();
+          });
+      });
+  }
+}
+
+module.exports.runApp = async () => {
+  let configObj = config.get();
+  let projectRunner = configObj.cli ? configObj.cli.projectRunner : undefined;
+
+  if (projectRunner && projectRunner.devCommand) {
+      return new Promise((resolve, _reject) => {
+          let cmd = projectRunner.devCommand;
+
+          utils.log(`Running Project Runner: ${cmd} ...`);
+          const proc = spawnCommand(cmd, { stdio: 'inherit'});
+          proc.on('exit', (code) => {
+              utils.log(`Project stopped with exit code: ${code}`);
+              resolve();
+          });
+      });
+  } else {
+    utils.error("Config file does not contain projectRunner.devCommand to run the project!!!");
+    process.exit(1);
+  }
+}

--- a/src/modules/projectRunner.js
+++ b/src/modules/projectRunner.js
@@ -12,14 +12,15 @@ module.exports.runCommand = async (commandKey) => {
   let configObj = config.get();
   let projectRunner = configObj.cli ? configObj.cli.projectRunner : undefined;
 
-  if (projectRunner && projectRunner[commandKey]) {
+  if (projectRunner && projectRunner.projectPath && projectRunner[commandKey]) {
 
       return new Promise((resolve, _reject) => {
+          let projectPath = utils.trimPath(projectRunner.projectPath);
           let cmd = projectRunner[commandKey];
 
           utils.log(`Running ${commandKey}: ${cmd}...`);
 
-          const proc = spawnCommand(cmd, { stdio: 'inherit'});
+          const proc = spawnCommand(cmd, { stdio: 'inherit', cwd: projectPath});
           proc.on('exit', (code) => {
               utils.log(`Project Runner: ${commandKey} completed with exit code: ${code}`);
               resolve();
@@ -32,12 +33,13 @@ module.exports.runApp = async () => {
   let configObj = config.get();
   let projectRunner = configObj.cli ? configObj.cli.projectRunner : undefined;
 
-  if (projectRunner && projectRunner.devCommand) {
+  if (projectRunner && projectRunner.projectPath && projectRunner.devCommand) {
       return new Promise((resolve, _reject) => {
+          let projectPath = utils.trimPath(projectRunner.projectPath);
           let cmd = projectRunner.devCommand;
 
           utils.log(`Running Project Runner: ${cmd} ...`);
-          const proc = spawnCommand(cmd, { stdio: 'inherit'});
+          const proc = spawnCommand(cmd, { stdio: 'inherit', cwd: projectPath});
           proc.on('exit', (code) => {
               utils.log(`Project stopped with exit code: ${code}`);
               resolve();


### PR DESCRIPTION
Supported to init, run, build Neutralino Apps with project runner

- supports neu config parameters like so under cli
```json
    "projectRunner": {
      "projectPath": "/",
      "buildPath": "./node-src/dist/",
      "initCommand": "npm run runner:install",  
      "devCommand": "npm run runner:start",     
      "buildCommand": "npm run runner:build"
    }
```
- `initCommand`, `devCommand`, `buildCommand` are run inside root of the Neu App
- could not understand the need of `type` attribute so did not include it

Todo: (in this [repo](https://github.com/neutralinojs-community/node-neutralino))

- add logic for running frontend library
- run binaries with new name when in build mode