### PR TITLE
:zap: Make sure Neutralino binaries have the right permissions

### DIFF
--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -188,6 +188,11 @@ module.exports.downloadAndUpdateBinaries = async (latest = false) => {
             let binaryFile = constants.files.binaries[platform][arch];
             if (fse.existsSync(`.tmp/${binaryFile}`)) {
                 fse.copySync(`.tmp/${binaryFile}`, `bin/${binaryFile}`);
+                // Ensure that correct permissions are set
+                // Non-applicable on Windows platform and not needed for Windows executables
+                if (process.platform !== 'win32' && platform !== 'win32') {
+                    fse.chmodSync(`bin/${binaryFile}`, '755');
+                }
             }
         }
     }

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -66,7 +66,7 @@ let getBinaryDownloadUrl = async (latest) => {
         config.update('cli.binaryVersion', version);
     }
     return constants.remote.binariesUrl
-        .replace(/{tag}/g, utils.getVersionTag(version));
+        .replace(/\{tag\}/g, utils.getVersionTag(version));
 }
 
 let getClientDownloadUrl = async (latest, types = false) => {
@@ -86,7 +86,7 @@ let getClientDownloadUrl = async (latest, types = false) => {
 
     let scriptUrl = constants.remote.clientUrlPrefix + (types ? 'd.ts' : getScriptExtension());
     return scriptUrl
-        .replace(/{tag}/g, utils.getVersionTag(version));
+        .replace(/\{tag\}/g, utils.getVersionTag(version));
 }
 
 let getTypesDownloadUrl = (latest) => {


### PR DESCRIPTION
A Mac user of ct.js reported that `npx @neutralinojs/neu create neuTestApp` downloaded binaries without the `+x` flags, which lead to `EPERM` errors or `Executable not found in $PATH` when run through other tools. Though I myself could not replicate it in a Mac VM, I suppose it is due to some security measure in newer macOS versions.

This PR adds a simple fs.chmodSync call on every non-windows binary when run on system other than Windows to make sure the executables have the right execution flags.

It also makes a function-less change to regEx statements in the code so VSCode's syntax highlighter doesn't break. (`<pattern>{N,M}` are used for quantifiers and ir seems that VSCode tokenizer detects any `{}` pair as one.)