### PR TITLE
neu build support specify neutralino.config.json

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -14,7 +14,7 @@ module.exports.register = (program) => {
         .action(async (command) => {
             if(command.configFile) {
               utils.log(`Using config file: ${command.configFile}`);
-              constants.files.configFile = command.neuJson;
+              constants.files.configFile = command.configFile;
             }
 
             utils.checkCurrentProject();

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,15 +1,22 @@
 const utils = require('../utils');
 const bundler = require('../modules/bundler');
 const config = require('../modules/config');
+const constants = require('../constants')
 
 module.exports.register = (program) => {
     program
         .command('build')
         .description('builds binaries for all supported platforms and resources.neu file')
         .option('-r, --release')
+        .option('--neu-json <path>', 'specify neutralino.config.json file')
         .option('--copy-storage')
         .option('--clean')
         .action(async (command) => {
+            if (command.neuJson) {
+              utils.log(`Using neu.json file: ${command.neuJson}`)
+              constants.files.configFile = command.neuJson
+            }
+
             utils.checkCurrentProject();
             const configObj = config.get()
             const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,20 +1,20 @@
 const utils = require('../utils');
 const bundler = require('../modules/bundler');
 const config = require('../modules/config');
-const constants = require('../constants')
+const constants = require('../constants');
 
 module.exports.register = (program) => {
     program
         .command('build')
         .description('builds binaries for all supported platforms and resources.neu file')
         .option('-r, --release')
-        .option('--neu-json <path>', 'specify neutralino.config.json file')
+        .option('--config-file <path>', 'specify the *.config.json file')
         .option('--copy-storage')
         .option('--clean')
         .action(async (command) => {
-            if (command.neuJson) {
-              utils.log(`Using neu.json file: ${command.neuJson}`)
-              constants.files.configFile = command.neuJson
+            if(command.configFile) {
+              utils.log(`Using config file file: ${command.configFile}`);
+              constants.files.configFile = command.neuJson;
             }
 
             utils.checkCurrentProject();

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -13,7 +13,7 @@ module.exports.register = (program) => {
         .option('--clean')
         .action(async (command) => {
             if(command.configFile) {
-              utils.log(`Using config file file: ${command.configFile}`);
+              utils.log(`Using config file: ${command.configFile}`);
               constants.files.configFile = command.neuJson;
             }
 

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -40,8 +40,8 @@ async function createAsarFile() {
         });
     }
 
-    // fix for neu build specify neutralino.config.json file
     await fse.copy(`${constants.files.configFile}`, `.tmp/neutralino.config.json`, { overwrite: true });
+    
     if (clientLibrary) {
         let typesFile = clientLibrary.replace(/.js$/, '.d.ts');
         await fse.copy(`./${clientLibrary}`, `.tmp/${clientLibrary}`, { overwrite: true });

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -40,7 +40,8 @@ async function createAsarFile() {
         });
     }
 
-    await fse.copy(`${constants.files.configFile}`, `.tmp/${constants.files.configFile}`, { overwrite: true });
+    // fix for neu build specify neutralino.config.json file
+    await fse.copy(`${constants.files.configFile}`, `.tmp/neutralino.config.json`, { overwrite: true });
     if (clientLibrary) {
         let typesFile = clientLibrary.replace(/.js$/, '.d.ts');
         await fse.copy(`./${clientLibrary}`, `.tmp/${clientLibrary}`, { overwrite: true });

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -1,14 +1,14 @@
 const editJsonFile = require('edit-json-file');
 const constants = require('../constants');
-const CONFIG_FILE = constants.files.configFile;
+const getConfigFile = () => constants.files.configFile;
 
 module.exports.update = (key, value) => {
-    let file = editJsonFile(CONFIG_FILE);
+    let file = editJsonFile(getConfigFile());
     file.set(key, value);
     file.save();
 };
 
 module.exports.get = () => {
-    let file = editJsonFile(CONFIG_FILE);
+    let file = editJsonFile(getConfigFile());
     return file.get();
 };


### PR DESCRIPTION
neu build now can specify neutralino.config.json by using --neu-json such as 
`neu build --neu-json neutralino.config_zhiyuan.json`

I have test it and the execute metadata  also is correct
![image](https://github.com/user-attachments/assets/2f5f4041-2221-400d-b8f9-219992fa74a0)
![image](https://github.com/user-attachments/assets/19ff25c2-8633-47e6-8a7d-501e41a7e21a)
---
Hope my work can help some guys.