### PR TITLE
Fix argument handling with spaces in neu run

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -5,6 +5,12 @@ const utils = require('../utils');
 const config = require('../modules/config');
 const frontendlib = require('../modules/frontendlib');
 const hostproject = require('../modules/hostproject');
+function wrapQuotedArguments(arg) {
+    if (arg.includes(' ') && !arg.startsWith('"') && !arg.endsWith('"')) {
+        return `"${arg}"`;
+    }
+    return arg;
+}
 
 module.exports.register = (program) => {
     program
@@ -42,6 +48,7 @@ module.exports.register = (program) => {
             if(parseStopIndex != -1) {
                 argsOpt += ' ' + process.argv
                                 .slice(parseStopIndex + 1)
+                                .map(wrapQuotedArguments)
                                 .join(' ');
             }
 


### PR DESCRIPTION
Fixes #279
# Description:
This PR addresses an issue in the Neutralinojs CLI where arguments containing spaces (e.g., file paths) were being split into multiple parameters. This is particularly problematic when using the `neu run` command with arguments like `--file="path with spaces.txt"`, which were incorrectly processed into separate arguments.

## Changes Made:
* Modified the argument parsing logic in the `run.js` file to properly handle parameters with spaces.
* Ensured that all arguments after `--` are treated as a single string, preserving spaces where needed.

### How It Works:
* The PR introduces logic to properly join the arguments passed after `--` into a single string, ensuring that the entire argument, including paths with spaces, is passed correctly to the application.

## Test:
* Created a test Neutralinojs project and used the following command to verify that arguments with spaces are handled correctly.

* my input
```
neu run -- --file="path with spaces.txt"
```
* outcome
```
neu: INFO Starting process: neutralino-win_x64.exe  --load-dir-res --path=. --export-auth-info --neu-dev-extension --neu-dev-auto-reload 
"--file=path with spaces.txt"
neu: INFO neu CLI connected with the application.
```