### PR TITLE
bumped spawn-process from 0.0.2 to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "png2icons": "^2.0.1",
         "recursive-readdir": "^2.2.2",
         "resedit": "^2.0.2",
-        "spawn-command": "^0.0.2-1",
+        "spawn-command": ">=1.0.0",
         "tcp-port-used": "^1.0.2",
         "uuid": "^8.3.2",
         "websocket": "^1.0.34",
@@ -811,9 +811,10 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "node_modules/spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-1.0.0.tgz",
+      "integrity": "sha512-zsboEQnjeF6tSJ8SRnojMr22HyFEaRaohgTt0Kgx3BgzkXYiboh09vpmZVIq1HOLzkFZDgFJJfwGUqSbb5fQQQ==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -1573,9 +1574,9 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-1.0.0.tgz",
+      "integrity": "sha512-zsboEQnjeF6tSJ8SRnojMr22HyFEaRaohgTt0Kgx3BgzkXYiboh09vpmZVIq1HOLzkFZDgFJJfwGUqSbb5fQQQ=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "png2icons": "^2.0.1",
         "recursive-readdir": "^2.2.2",
         "resedit": "^2.0.2",
-        "spawn-command": ">=1.0.0",
+        "spawn-command": "^1.0.0",
         "tcp-port-used": "^1.0.2",
         "uuid": "^8.3.2",
         "websocket": "^1.0.34",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "png2icons": "^2.0.1",
     "recursive-readdir": "^2.2.2",
     "resedit": "^2.0.2",
-    "spawn-command": ">=1.0.0",
+    "spawn-command": "^1.0.0",
     "tcp-port-used": "^1.0.2",
     "uuid": "^8.3.2",
     "websocket": "^1.0.34",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "png2icons": "^2.0.1",
     "recursive-readdir": "^2.2.2",
     "resedit": "^2.0.2",
-    "spawn-command": "^0.0.2-1",
+    "spawn-command": ">=1.0.0",
     "tcp-port-used": "^1.0.2",
     "uuid": "^8.3.2",
     "websocket": "^1.0.34",


### PR DESCRIPTION
fixes #287 

Moved outdated ``spawn-command`` dependency from ``0.0.2`` to ``1.0.0`` in ``package.json`` and ``package-lock.json``
