### PR TITLE
Fixes: Rename macOS output folder to .app in neu build

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -125,6 +125,10 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
             fse.copySync(utils.trimPath(hostProjectConfig.buildPath), `${buildDir}/${binaryName}/`);
         }
 
+        if(configObj.cli.macOutputAsAppBundle){
+            renameMacApp(`${buildDir}/${binaryName}/`, binaryName);
+        }
+
         if (isRelease) {
             utils.log('Making app bundle ZIP file...');
             await zl.archiveFolder(`${buildDir}/${binaryName}`, `${buildDir}/${binaryName}-release.zip`);
@@ -134,4 +138,18 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
     catch (e) {
         utils.error(e);
     }
+}
+
+function renameMacApp(outputDir, appName) {
+    const architectures = ['mac_x64', 'mac_arm64', 'mac_universal'];
+
+    architectures.forEach((arch) => {
+        const oldPath = path.join(outputDir, `${appName}-${arch}`);
+        const newPath = path.join(outputDir, `${appName}-${arch}.app`);
+
+        if (fs.existsSync(oldPath)) {
+            fs.renameSync(oldPath, newPath);
+            utils.log(`Renamed macOS app to: ${newPath}`);
+        }
+    });
 }

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -141,15 +141,17 @@ module.exports.bundleApp = async (isRelease, copyStorage) => {
 }
 
 function renameMacApp(outputDir, appName) {
-    const architectures = ['mac_x64', 'mac_arm64', 'mac_universal'];
+    const architectures = Object.keys(constants.files.binaries.darwin);
 
     architectures.forEach((arch) => {
-        const oldPath = path.join(outputDir, `${appName}-${arch}`);
-        const newPath = path.join(outputDir, `${appName}-${arch}.app`);
+
+        const binaryFile = constants.files.binaries.darwin[arch].replace('neutralino', appName);
+        const oldPath = path.join(outputDir, binaryFile);
+        const newPath = path.join(outputDir, `${binaryFile}.app`);
 
         if (fs.existsSync(oldPath)) {
             fs.renameSync(oldPath, newPath);
-            utils.log(`Renamed macOS app to: ${newPath}`);
+            utils.log(`Renamed macOS app to: ${binaryFile}.app`);
         }
     });
 }


### PR DESCRIPTION
Fixes #231 by @hypherionmc 

## Add `macOutputAsAppBundle` option to rename macOS output folder to `.app`.
## Description:
This PR adds support for renaming the macOS build output folder to `.app` when neu build runs. The behavior is configurable via a new option in `neutralino.config.json`.

#### Problem:
Currently, after running neu build, the macOS build outputs a folder named:

* `MyApp-mac_x64`
* `MyApp-mac_arm64`
* `MyApp-mac_universal`

This is not in the expected .app format, which can cause confusion and inconvenience for users.

#### Solution:

* Introduced a new config option in neutralino.config.json
```
{
  "cli": {
    "macOutputAsAppBundle": true
  }
}

```
* If `macOutputAsAppBundle` is enabled, the output folder will be renamed to `.app`.
* Supports all three architectures (mac_x64, mac_arm64, mac_universal).
* Prevents overwriting issues by preserving separate .app files for each architecture.

### Tests:
- [x] Verified that the .app extension is applied only when enabled in config.
- [x] Confirmed separate .app files for different architectures.


