### PR TITLE
#78 added changes build size reducers 

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -25,10 +25,9 @@ async function createAsarFile() {
     await fse.copy(`./${resourcesDir}`, `.tmp/${resourcesDir}`, {
         overwrite: true,
         filter: configObj.cli.resourcesExclude
-            && ((src) =>
-                (!new RegExp(configObj.cli.resourcesExclude).test(src))
-            )
-    });
+          ? (src) => !new RegExp(configObj.cli.resourcesExclude).test(src)
+          : undefined
+      });
 
     if (extensionsDir && fs.existsSync(extensionsDir)) {
         await fse.copy(`./${extensionsDir}`, `${buildDir}/${binaryName}/${extensionsDir}`, {


### PR DESCRIPTION
 fix that bundle size is greater maken as smaller
  for that working follow below steps:

step 1. Update neutralino.config.json:

step 2. Open your project's neutralino.config.json file.

step 3. Add or modify the cli section to include the resourcesExclude property with appropriate patterns. For example:
{
  "cli": {
    "resourcesExclude": ".*\\.scss$|.*\\.d.ts$|.*\\.map$|.*\\.test\\.js$"
  }
}
in your local project i think it will decrease build size of the project