### PR TITLE
feat: Add support for embedding resources in the build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "fs-extra": "^9.0.1",
         "pe-library": "^1.0.1",
         "png2icons": "^2.0.1",
+        "postject": "1.0.0-alpha.6",
         "recursive-readdir": "^2.2.2",
         "resedit": "^2.0.2",
         "spawn-command": "^1.0.0",
@@ -721,6 +722,30 @@
       "integrity": "sha512-GDEQJr8OG4e6JMp7mABtXFSEpgJa1CCpbQiAR+EjhkHJHnUL9zPPtbOrjsMD8gUbikgv3j7x404b0YJsV3aVFA==",
       "bin": {
         "png2icons": "png2icons-cli.js"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/prettier": {
@@ -1519,6 +1544,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/png2icons/-/png2icons-2.0.1.tgz",
       "integrity": "sha512-GDEQJr8OG4e6JMp7mABtXFSEpgJa1CCpbQiAR+EjhkHJHnUL9zPPtbOrjsMD8gUbikgv3j7x404b0YJsV3aVFA=="
+    },
+    "postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "requires": {
+        "commander": "^9.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
+        }
+      }
     },
     "prettier": {
       "version": "3.2.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fs-extra": "^9.0.1",
     "pe-library": "^1.0.1",
     "png2icons": "^2.0.1",
+    "postject": "1.0.0-alpha.6",
     "recursive-readdir": "^2.2.2",
     "resedit": "^2.0.2",
     "spawn-command": "^1.0.0",

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -8,6 +8,7 @@ module.exports.register = (program) => {
         .command('build')
         .description('builds binaries for all supported platforms and resources.neu file')
         .option('-r, --release')
+        .option('--embed-resources', 'embed resources in the binary')
         .option('--config-file <path>', 'specify the *.config.json file')
         .option('--copy-storage')
         .option('--clean')
@@ -28,6 +29,7 @@ module.exports.register = (program) => {
             utils.log('Bundling app...');
             await bundler.bundleApp({
                 release: command.release, 
+                embedResources: command.embedResources,
                 copyStorage: command.copyStorage,
                 macosBundle: command.macosBundle
             });

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,14 @@ module.exports = {
     },
     dependencies: []
   },
+  embedded: {
+    resourceName: "NEUTRALINOJS_RESOURCES_NEU",
+    fixSentinelFuse: "XOSTJECT_SENTINEL_fce680ab2cc467b6e072b8b5df1996b2",
+    options: {
+      overwrite: true,
+      sentinelFuse: "POSTJECT_SENTINEL_fce680ab2cc467b6e072b8b5df1996b2"
+    }
+  },
   misc: {
     hotReloadLibPatchRegex: /(<script.*src=")(.*neutralino.js)(".*><\/script>)/g,
     hotReloadGlobPatchRegex: /(<script.*src=")(.*__neutralino_globals.js)(".*><\/script>)/g


### PR DESCRIPTION
# feat: Add support for embedding resources in the build process

Hi! With this PR I want to finish the new `Single-File` build mode, embedding the `resources.neu` inside each binary using `postject`. I opened another [`PR #402`](https://github.com/neutralinojs/neutralinojs.github.io/pull/402) at the website with documentation; you can check it if you want.

## Example

First of all, I created an [example](https://github.com/IsmaCortGtz/neutralino-features-samples/tree/feature/portable) repository building with GitHub Actions; you can download the results [here](https://github.com/IsmaCortGtz/neutralino-features-samples/releases/tag/feat-portable). I can only test in `linux_x64` and `win_x64`, so any feedback about any other platform/architecture is very appreciated.  =)

## The new flag

The new `--embed-resources` flag is under the build command, so it can be used with `neu build --embed-resources`. This flag only injects the `resources.neu` file inside every executable after copying it in the `dist/` folder, so any other flag will still be compatible.

> [!NOTE]  
> `mac_universal` is made by joining `mac_x64` and `mac_arm64`, for this reason, the inject process temporally changes the first sentinel fuse and returns it after using `postject`. By default `postject` only allows one sentinel per file (A universal build has two, one for `x64` and other for `arm64`. See [here](https://github.com/nodejs/postject/issues/92) for an example)

### The `--help` result

So, this will be the new message for the `neu build -h` command:

```bash
  _   _            _             _ _             _
 | \ | | ___ _   _| |_ _ __ __ _| (_)_ __   ___ (_)___
 |  \| |/ _ \ | | | __| '__/ _' | | | '_ \ / _ \| / __|
 | |\  |  __/ |_| | |_| | | (_| | | | | | | (_) | \__ \
 |_| \_|\___|\__,_|\__|_|  \__,_|_|_|_| |_|\___// |___/
                                               |__/
Usage: neu build [options]

builds binaries for all supported platforms and resources.neu file

Options:
  -r, --release
  --embed-resources     embed resources in the binary
  --config-file <path>  specify the *.config.json file
  --copy-storage
  --clean
  --macos-bundle
  -h, --help            display help for command
```

## Size difference

There is the original executables' size.

```bash
-rwxr-xr-x 1 ismael ismael 1.8M sep 13 17:10 neutralino-linux_arm64
-rwxr-xr-x 1 ismael ismael 1.4M sep 13 17:10 neutralino-linux_armhf
-rwxr-xr-x 1 ismael ismael 1.7M sep 13 17:10 neutralino-linux_x64
-rwxr-xr-x 1 ismael ismael 2.2M sep 13 17:10 neutralino-mac_arm64
-rwxr-xr-x 1 ismael ismael 4.4M sep 13 17:10 neutralino-mac_universal
-rwxr-xr-x 1 ismael ismael 2.2M sep 13 17:10 neutralino-mac_x64
-rw-r--r-- 1 ismael ismael 2.5M sep 13 17:10 neutralino-win_x64.exe
```

And there is the final size with the resources injected. (The `resources.neu` file had a `272K` size).

```bash
-rwxr-xr-x 1 ismael ismael 2.2M sep 13 17:18 my-neu-app-linux_arm64
-rwxr-xr-x 1 ismael ismael 1.8M sep 13 17:18 my-neu-app-linux_armhf
-rwxr-xr-x 1 ismael ismael 2.1M sep 13 17:18 my-neu-app-linux_x64
-rwxr-xr-x 1 ismael ismael 2.4M sep 13 17:18 my-neu-app-mac_arm64
-rwxr-xr-x 1 ismael ismael 4.7M sep 13 17:18 my-neu-app-mac_universal
-rwxr-xr-x 1 ismael ismael 2.4M sep 13 17:18 my-neu-app-mac_x64
-rw-r--r-- 1 ismael ismael 2.8M sep 13 17:18 my-neu-app-win_x64.exe
```

> [!IMPORTANT]  
> Keep in mind that injection by [`nodejs/postject`](https://github.com/nodejs/postject) relies on [`lief-project/LIEF`](https://github.com/lief-project/LIEF) implementation and the platform specification, so the final size could increase more than the `resource.neu` size. 

Again, I can only test this in `linux_x64` and `win_x64`, so any feedback about other platform/architecture is very appreciated.  =)