### PR TITLE
Fix #1431: Support custom config file in build command

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -15,8 +15,8 @@ module.exports.register = (program) => {
         .option('--macos-bundle')
         .action(async (command) => {
             if(command.configFile) {
-              utils.log(`Using config file: ${command.configFile}`);
-              constants.files.configFile = command.configFile;
+             constants.files.configFile = command.configFile;
+             utils.log(`Using config file: ${constants.files.configFile}`);
             }
 
             utils.checkCurrentProject();

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -1,6 +1,13 @@
 const editJsonFile = require('edit-json-file');
 const constants = require('../constants');
-const getConfigFile = () => constants.files.configFile;
+
+const getConfigFile = () => {
+    let argIndex = process.argv.indexOf('--config-file');
+    if (argIndex !== -1 && process.argv[argIndex + 1]) {
+        return process.argv[argIndex + 1];
+    }
+    return constants.files.configFile;
+};
 
 module.exports.update = (key, value) => {
     let file = editJsonFile(getConfigFile());

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@ const process = require('process');
 const exec = require('child_process').exec;
 const chalk = require('chalk');
 const constants = require('./constants');
-const CONFIG_FILE = constants.files.configFile;
+let getConfigFile = () => constants.files.configFile;
 const config = require('./modules/config')
 const package = require('../package.json')
 
@@ -13,7 +13,7 @@ let error = (message) => {
 }
 
 let isNeutralinojsProject = (parent = '.') => {
-    return fs.existsSync(parent + '/' +  CONFIG_FILE);
+    return fs.existsSync(parent + '/' + getConfigFile());
 }
 
 let getFiglet = () => {
@@ -34,13 +34,13 @@ let showArt = () => {
 
 let checkCurrentProject = () => {
     if (!isNeutralinojsProject()) {
-        error(`Unable to find ${CONFIG_FILE}. ` +
+        error(`Unable to find ${getConfigFile()}. ` +
             `Please check whether the current directory has a Neutralinojs project.`);
         process.exit(1);
     }
-    const configObj =  config.get();
+    const configObj = config.get();
     if(Object.keys(configObj).length == 0) {
-        error(`${CONFIG_FILE} is not a valid Neutralinojs configuration JSON file.`);
+        error(`${getConfigFile()} is not a valid Neutralinojs configuration JSON file.`);
         process.exit(1);
     }
 }


### PR DESCRIPTION
Fixes #1431

I've updated the build command so it actually respects the --config-file argument. 

Previously, even if you passed a custom config, the CLI's internal "Gatekeeper" checks in utils.js were still hardcoded to look for neutralino.config.json, causing the build to fail before it even started.

What I changed :
 In `config.js`, I updated `getConfigFile` to look for the flag in process.argv so the CLI knows which file to read from the start.
-In `utils.js`, I swapped the hardcoded `CONFIG_FILE` constant for a dynamic `getConfigFile()` function. This stops the "Unable to find neutralino.config.json" error when using a custom name.
 In `build.js`, I made sure the global constant is updated before the project validation runs.

Tested this locally by creating a `custom.json` and running `neu build --config-file=custom.json`. It now correctly picks up the custom file instead of crashing.