### PR TITLE
#299  fix: cleanup frontend dev server on application exit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "resedit": "^2.0.2",
         "spawn-command": "^1.0.0",
         "tcp-port-used": "^1.0.2",
+        "tree-kill": "^1.2.2",
         "uuid": "^8.3.2",
         "websocket": "^1.0.34",
         "zip-lib": "^1.0.4"
@@ -894,6 +895,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -1658,6 +1668,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "resedit": "^2.0.2",
     "spawn-command": "^1.0.0",
     "tcp-port-used": "^1.0.2",
+    "tree-kill": "^1.2.2",
     "uuid": "^8.3.2",
     "websocket": "^1.0.34",
     "zip-lib": "^1.0.4"

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -7,39 +7,58 @@ const frontendlib = require('../modules/frontendlib');
 module.exports.register = (program) => {
     program
         .command('build')
-        .description('builds binaries for all supported platforms and resources.neu file')
+        .description('Builds binaries for all supported platforms and resources.neu file')
         .option('-r, --release')
-        .option('--embed-resources', 'embed resources in the binary')
-        .option('--config-file <path>', 'specify the *.config.json file')
+        .option('--embed-resources', 'Embed resources in the binary')
+        .option('--config-file <path>', 'Specify the *.config.json file')
         .option('--copy-storage')
         .option('--clean')
         .option('--macos-bundle')
         .action(async (command) => {
-            if(command.configFile) {
-              utils.log(`Using config file: ${command.configFile}`);
-              constants.files.configFile = command.configFile;
+            // Use custom config file if provided
+            if (command.configFile) {
+                utils.log(`Using config file: ${command.configFile}`);
+                constants.files.configFile = command.configFile;
             }
 
             utils.checkCurrentProject();
-            if(frontendlib.containsFrontendLibApp()) {
-                await frontendlib.runCommand('buildCommand', true);
-            }
-            const configObj = config.get()
+
+            if (frontendlib.containsFrontendLibApp()) {
+    utils.log('Running frontend build...');
+    const proc = frontendlib.runCommand('buildCommand');
+
+    if (proc) {
+        await new Promise((resolve, reject) => {
+            proc.on('exit', (code) => code === 0 ? resolve() : reject(new Error(`Frontend build exited with code ${code}`)));
+            proc.on('error', reject);
+        });
+        utils.log('Frontend build finished.');
+    }
+
+    // Prevent bundler from running frontend build
+    frontendlib.runCommand = () => null;
+}
+
+
+            // Get distribution path
+            const configObj = config.get();
             const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
-            if(command.clean) {
+
+            if (command.clean) {
                 utils.log(`Cleaning previous build files from ${buildDir}...`);
                 utils.clearDirectory(buildDir);
             }
+
             utils.log('Bundling app...');
             await bundler.bundleApp({
-                release: command.release, 
+                release: command.release,
                 embedResources: command.embedResources,
                 copyStorage: command.copyStorage,
                 macosBundle: command.macosBundle
             });
+
             utils.showArt();
             utils.log(`Application package was generated at the ${buildDir} directory!`);
             utils.log('Distribution guide: https://neutralino.js.org/docs/distribution/overview');
         });
 }
-

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -15,7 +15,6 @@ module.exports.register = (program) => {
         .option('--clean')
         .option('--macos-bundle')
         .action(async (command) => {
-            // Use custom config file if provided
             if (command.configFile) {
                 utils.log(`Using config file: ${command.configFile}`);
                 constants.files.configFile = command.configFile;
@@ -23,26 +22,10 @@ module.exports.register = (program) => {
 
             utils.checkCurrentProject();
 
-            if (frontendlib.containsFrontendLibApp()) {
-    utils.log('Running frontend build...');
-    const proc = frontendlib.runCommand('buildCommand');
-
-    if (proc) {
-        await new Promise((resolve, reject) => {
-            proc.on('exit', (code) => code === 0 ? resolve() : reject(new Error(`Frontend build exited with code ${code}`)));
-            proc.on('error', reject);
-        });
-        utils.log('Frontend build finished.');
-    }
-
-    // Prevent bundler from running frontend build
-    frontendlib.runCommand = () => null;
-}
-
-
-            // Get distribution path
             const configObj = config.get();
-            const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
+            const buildDir = configObj.cli.distributionPath
+                ? utils.trimPath(configObj.cli.distributionPath)
+                : 'dist';
 
             if (command.clean) {
                 utils.log(`Cleaning previous build files from ${buildDir}...`);
@@ -61,4 +44,4 @@ module.exports.register = (program) => {
             utils.log(`Application package was generated at the ${buildDir} directory!`);
             utils.log('Distribution guide: https://neutralino.js.org/docs/distribution/overview');
         });
-}
+};

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -2,6 +2,7 @@ const utils = require('../utils');
 const bundler = require('../modules/bundler');
 const config = require('../modules/config');
 const constants = require('../constants');
+const frontendlib = require('../modules/frontendlib');
 
 module.exports.register = (program) => {
     program
@@ -20,6 +21,9 @@ module.exports.register = (program) => {
             }
 
             utils.checkCurrentProject();
+            if(frontendlib.containsFrontendLibApp()) {
+                await frontendlib.runCommand('buildCommand', true);
+            }
             const configObj = config.get()
             const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
             if(command.clean) {

--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const process = require('process');
+const kill = require('tree-kill');
 const spawnCommand = require('spawn-command');
 const recursive = require('recursive-readdir');
 const tpu = require('tcp-port-used');
@@ -147,9 +148,15 @@ module.exports.waitForFrontendLibApp = async () => {
     clearInterval(inter);
 }
 module.exports.stopDevServer = () => {
-    if (devServerProcess) {
+    if (devServerProcess && devServerProcess.pid) {
         utils.log('Stopping frontend dev server...');
-        devServerProcess.kill();
+
+        kill(devServerProcess.pid, 'SIGTERM', (err) => {
+            if (err) {
+                // Fail silently if the process was already closed
+            }
+        });
+
         devServerProcess = null;
     }
 };

--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -10,9 +10,11 @@ const utils = require('../utils');
 
 const HOT_REL_LIB_PATCH_REGEX = constants.misc.hotReloadLibPatchRegex;
 const HOT_REL_GLOB_PATCH_REGEX = constants.misc.hotReloadGlobPatchRegex;
+
 let originalClientLib = null;
 let originalGlobals = null;
 let devServerProcess = null;
+let isBuildFinished = false;
 
 async function makeClientLibUrl(port) {
     let configObj = config.get();
@@ -20,13 +22,13 @@ async function makeClientLibUrl(port) {
     let files = await recursive(resourcesPath);
     let clientLib = files.find((file) => /neutralino\.js$/.test(file));
     if (clientLib) {
-        clientLib = clientLib.replace(/\\/g, '/'); // Fix path on Windows
+        clientLib = clientLib.replace(/\\/g, '/');
     }
     let url = `http://localhost:${port}`;
 
-    if(clientLib) {
+    if (clientLib) {
         clientLib = '/' + clientLib;
-        if(configObj.documentRoot) {
+        if (configObj.documentRoot) {
             clientLib = clientLib.replace(configObj.documentRoot, '/');
         }
         url += clientLib;
@@ -43,7 +45,7 @@ function patchHTMLFile(scriptFile, regex) {
     let patchFile = configObj.cli.frontendLibrary.patchFile.replace(/^\//, '');
     let html = fs.readFileSync(patchFile, 'utf8');
     let matches = regex.exec(html);
-    if(matches) {
+    if (matches) {
         html = html.replace(regex, `$1${scriptFile}$3`);
         fs.writeFileSync(patchFile, html);
         return matches[2];
@@ -53,90 +55,120 @@ function patchHTMLFile(scriptFile, regex) {
 
 function getPortByProtocol(protocol) {
     switch (protocol) {
-        case 'http:':
-          return 80;
-        case 'https:':
-            return 443;
-        case 'ftp:':
-          return 21;
-        default:
-            return -1;
-      }
+        case 'http:': return 80;
+        case 'https:': return 443;
+        case 'ftp:': return 21;
+        default: return -1;
+    }
 }
 
 module.exports.bootstrap = async (port) => {
     let configObj = config.get();
-    if(configObj.cli.clientLibrary) {
+    if (configObj.cli.clientLibrary) {
         let clientLibUrl = await makeClientLibUrl(port);
         originalClientLib = patchHTMLFile(clientLibUrl, HOT_REL_LIB_PATCH_REGEX);
     }
     let globalsUrl = await makeGlobalsUrl(port);
     originalGlobals = patchHTMLFile(globalsUrl, HOT_REL_GLOB_PATCH_REGEX);
-    utils.warn('Global variables patch was applied successfully. ' +
-        'Please avoid sending keyboard interrupts.');
-    utils.log(`You are working with your frontend library's development environment. ` +
-        'Your frontend-library-based app will run with Neutralino and be able to use the Neutralinojs API.');
-}
+    utils.warn(
+        'Global variables patch was applied successfully. ' +
+        'Please avoid sending keyboard interrupts.'
+    );
+    utils.log(
+        'You are working with your frontend library\'s development environment. ' +
+        'Your frontend-library-based app will run with Neutralino and be able to use the Neutralinojs API.'
+    );
+};
 
 module.exports.cleanup = () => {
-    if(originalClientLib) {
+    if (originalClientLib) {
         patchHTMLFile(originalClientLib, HOT_REL_LIB_PATCH_REGEX);
     }
-    if(originalGlobals) {
+    if (originalGlobals) {
         patchHTMLFile(originalGlobals, HOT_REL_GLOB_PATCH_REGEX);
     }
     utils.log('Global variables patch was reverted.');
-}
-
+};
 
 module.exports.runCommand = (commandKey) => {
-    let cli = config.get().cli;
-    let frontendLib = cli && cli.frontendLibrary;
-    if(frontendLib && frontendLib.projectPath && frontendLib[commandKey]) {
-        const projectPath = utils.trimPath(frontendLib.projectPath);
-        const cmd = frontendLib[commandKey];
+    let configObj = config.get();
+    let frontendLib = configObj.cli ? configObj.cli.frontendLibrary : undefined;
+
+    if (frontendLib && frontendLib.projectPath && frontendLib[commandKey]) {
+        let projectPath = utils.trimPath(frontendLib.projectPath);
+        let cmd = frontendLib[commandKey];
+
         utils.log(`Running ${commandKey}: ${cmd}...`);
         devServerProcess = spawnCommand(cmd, { stdio: 'inherit', cwd: projectPath });
-        return devServerProcess;  // return the process instead of Promise
+
+       return new Promise((resolve, reject) => {
+            devServerProcess.on('exit', (code) => {
+                if (code === 0 || devServerProcess === null) {
+                    resolve();
+                } else {
+                    reject(new Error(`Process exited with code ${code}`));
+                }
+            });
+            devServerProcess.on('error', reject);
+        });
     }
 };
 
 module.exports.containsFrontendLibApp = () => {
     let configObj = config.get();
     return !!(configObj.cli && configObj.cli.frontendLibrary);
-}
+};
 
 module.exports.waitForFrontendLibApp = async () => {
     let configObj = config.get();
-    let devUrlString = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.devUrl : undefined;
-    let timeout = configObj.cli && configObj.cli.frontendLibrary && configObj.cli.frontendLibrary.waitTimeout | 20000;
+    let devUrlString = configObj.cli && configObj.cli.frontendLibrary
+        ? configObj.cli.frontendLibrary.devUrl
+        : undefined;
+
+    let timeout = configObj.cli &&
+        configObj.cli.frontendLibrary &&
+        configObj.cli.frontendLibrary.waitTimeout | 20000;
+
     let url = new URL(devUrlString);
     let portString = url.port;
-    let port = portString ? Number.parseInt(portString) : getPortByProtocol(url.protocol)
+    let port = portString
+        ? Number.parseInt(portString)
+        : getPortByProtocol(url.protocol);
+
     if (port < 0) {
-        utils.error(`Could not get frontendLibrary port of ${devUrlString} with protocol ${url.protocol}`);
+        utils.error(
+            `Could not get frontendLibrary port of ${devUrlString} with protocol ${url.protocol}`
+        );
         process.exit(1);
     }
 
     let inter = setInterval(() => {
-        utils.log(`App will be launched when ${devUrlString} on port ${port} is ready...`);
+        utils.log(
+            `App will be launched when ${devUrlString} on port ${port} is ready...`
+        );
     }, 2500);
 
     try {
         await tpu.waitUntilUsedOnHost(port, url.hostname, 200, timeout);
-    }
-    catch(e) {
-        utils.error(`Timeout exceeded while waiting till local TCP port: ${port}`);
+    } catch (e) {
+        utils.error(
+            `Timeout exceeded while waiting till local TCP port: ${port}`
+        );
         process.exit(1);
     }
     clearInterval(inter);
-}
-process.on('exit', () => {
+};
+module.exports.stopDevServer = () => {
     if (devServerProcess && devServerProcess.pid) {
-        utils.log('Cleaning up dev server on exit...');
+        utils.log('Cleaning up dev server...');
         kill(devServerProcess.pid, 'SIGTERM');
         devServerProcess = null;
     }
+};
+
+process.on('exit', () => {
+    // Simply call the function we exported above
+    module.exports.stopDevServer();
 });
 
 process.on('SIGINT', () => {

--- a/src/modules/runner.js
+++ b/src/modules/runner.js
@@ -41,6 +41,7 @@ module.exports.runApp = async (options = {}) => {
         neuProcess.on('exit', function (code) {
             let statusCodeMsg = code ? `error code ${code}` : `success code 0`;
             let runnerMsg = `${binaryName} was stopped with ${statusCodeMsg}`;
+            frontendlib.stopDevServer();
 
             if(code) {
                 utils.warn(runnerMsg);
@@ -53,3 +54,7 @@ module.exports.runApp = async (options = {}) => {
         });
     });
 }
+    process.on('SIGINT', () => {
+    frontendlib.stopDevServer();
+    process.exit();
+});


### PR DESCRIPTION
#299 

Currently, when using the frontendLibrary feature, the dev server (e.g., Vite, Webpack) remains running in the background even after the Neutralino window is closed. This causes port conflicts when trying to run the app again.
I've updated the process management to track the spawned dev server and ensure it is properly terminated when the main application exits.

What I changed:
frontendlib.js:
Added a global devServerProcess variable to track the spawned command.
Updated runCommand to resolve immediately (non-blocking) so the Neutralino window can launch while the server runs.
Added an error listener to catch failed command executions.
Added a stopDevServer export to kill the process.

runner.js:
Called frontendlib.stopDevServer() inside the neuProcess exit listener.
Added a SIGINT listener at the file level so the dev server also dies if the user hits Ctrl+C in the terminal.