### PR TITLE
Fix race condition in plugin test install/remove

### DIFF
--- a/src/plugins/pluginloader.js
+++ b/src/plugins/pluginloader.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const { exec } = require('child_process');
+const { promisify } = require('util');
+const execAsync = promisify(exec);
 const package = require('../../package.json');
 const NEU_ROOT = path.join(__dirname, '../../');
 const Configstore = require('configstore');
@@ -64,68 +66,100 @@ let isPluginInstalled = (pluginName) => {
     }
 }
 
+module.exports.addTest = async (pluginPath) => {
+  let statsObj;
+  try {
+    statsObj = fs.statSync(pluginPath);
+  } catch (e) {
+    utils.error(`${e.message}`);
+    process.exit(1);
+  }
 
-module.exports.addTest = (pluginPath) => {
-    let statsObj;
-    try {
-      statsObj = fs.statSync(pluginPath);
-    } catch (e) {
-      utils.error(`${e.message}`);
+  if (!statsObj.isDirectory() || !fs.existsSync(pluginPath)) {
+    utils.error(`${pluginPath} is not a valid path`);
+    process.exit(1);
+  }
 
-      process.exit(1);
+  const packageJson = require(path.join(pluginPath, 'package.json'));
+  if (!packageJson) {
+    utils.error('Cannot find package.json file');
+    process.exit(1);
+  }
+
+  const pluginName = packageJson.name;
+  if (!pluginName) {
+    utils.error('Your plugin has no name. Please add name in package.json');
+    process.exit(1);
+  }
+
+  let plugins = [];
+  if (config.has('plugins')) plugins = config.get('plugins');
+
+  if (isPluginInstalled(pluginName)) {
+    throw `${pluginName} is already installed!`;
+  }
+
+  try {
+    await execAsync(`cd ${pluginPath} && npm link`);
+    await execAsync(`cd ${NEU_ROOT} && npm install ${pluginPath}`);
+
+    if (!plugins.includes(pluginName)) {
+      plugins.push(pluginName);
+      config.set('plugins', plugins);
     }
+  } catch (e) {
+    throw e.stderr || e;
+  }
+};
 
-    if (!statsObj.isDirectory() || !fs.existsSync(pluginPath)) {
-      utils.error(`${pluginPath} is not a valid path`);
 
-      process.exit(1);
-    }
 
-    const packageJson = require(path.join(pluginPath, 'package.json'));
+module.exports.removeTest = async (pluginPath) => {
+  let pluginName, packageJson, statsObj;
+
+  try {
+    statsObj = fs.statSync(pluginPath);
+  } catch (e) {
+    pluginName = pluginPath;
+  }
+
+  if (!pluginName && (!statsObj || !statsObj.isDirectory() || !fs.existsSync(pluginPath))) {
+    utils.error(`${pluginPath} is not a valid file path`);
+    process.exit(1);
+  } else {
+    packageJson = require(path.join(pluginPath, 'package.json'));
     if (!packageJson) {
       utils.error('Cannot find package.json file');
-
       process.exit(1);
     }
 
-    const pluginName = packageJson.name;
+    pluginName = packageJson.name;
     if (!pluginName) {
       utils.error('Your plugin has no name. Please add name in package.json');
-
       process.exit(1);
     }
+  }
 
-    return new Promise((resolve, reject) => {
-      let plugins = [];
-      if (config.has('plugins')) plugins = config.get('plugins');
-      if (!isPluginInstalled(pluginName)) {
-        exec(`cd ${pluginPath} && npm link`, (err, stdout, stderr) => {
-          if (err) {
-            reject(stderr);
-          } else if (!plugins.includes(pluginName)) {
-            plugins.push(pluginName);
-            config.set('plugins', plugins);
-          }
-          resolve();
-        });
+  let plugins = [];
+  if (config.has('plugins')) plugins = config.get('plugins');
 
-        exec(
-          `cd ${NEU_ROOT} && npm install ${pluginPath}`,
-          (err, stdout, stderr) => {
-            if (err) {
-              reject(stderr);
-            } else if (!plugins.includes(pluginName)) {
-              plugins.push(pluginName);
-              config.set('plugins', plugins);
-            }
-            resolve();
-          }
-        );
-      } else {
-        reject(`${pluginName} is already installed!`);
-      }
-    });
-  };
+  if (!plugins.includes(pluginName)) {
+    throw `Unable to find ${pluginName}!`;
+  }
+
+  try {
+    
+    await execAsync(`npm rm -g ${pluginName}`);
+
+    await execAsync(`cd ${NEU_ROOT} && npm uninstall ${pluginName}`);
+
+    plugins.splice(plugins.indexOf(pluginName), 1);
+    config.set('plugins', plugins);
+  } catch (e) {
+    throw e.stderr || e;
+  }
+};
+
 
 module.exports.remove = (pluginName, uninstallSuccessCallback) => {
     return new Promise((resolve, reject) => {
@@ -150,66 +184,7 @@ module.exports.remove = (pluginName, uninstallSuccessCallback) => {
     });
 };
 
-module.exports.removeTest = (pluginPath, uninstallSuccessCallback) => {
-    let pluginName, packageJson, statsObj;
 
-    try {
-      statsObj = fs.statSync(pluginPath);
-    } catch (e) {
-      pluginName = pluginPath;
-    }
-
-    if (!pluginName && (!statsObj || !statsObj.isDirectory() || !fs.existsSync(pluginPath))) {
-      utils.error(`${pluginPath} is not a valid file path`);
-
-      process.exit(1);
-    } else {
-      packageJson = require(path.join(pluginPath, 'package.json'));
-      if (!packageJson) {
-        utils.error('Cannot find package.json file');
-
-        process.exit(1);
-      }
-
-      pluginName = packageJson.name;
-      if (!pluginName) {
-        utils.error('Your plugin has no name. Please add name in package.json');
-
-        process.exit(1);
-      }
-    }
-
-    return new Promise((resolve, reject) => {
-      let plugins = [];
-      if (config.has('plugins')) plugins = config.get('plugins');
-      if (plugins.includes(pluginName)) {
-        exec(`npm rm -g ${pluginName}`, (err, stdout, stderr) => {
-          if (err) {
-            reject(stderr);
-          } else {
-            plugins.splice(plugins.indexOf(pluginName), 1);
-            config.set('plugins', plugins);
-            resolve();
-          }
-        });
-
-        exec(
-          `cd ${NEU_ROOT} && npm uninstall ${pluginName}`,
-          (err, stdout, stderr) => {
-            if (err) {
-              reject(stderr);
-            } else {
-              plugins.splice(plugins.indexOf(pluginName), 1);
-              config.set('plugins', plugins);
-              resolve();
-            }
-          }
-        );
-      } else {
-        reject(`Unable to find ${pluginName}!`);
-      }
-    });
-  };
 
 module.exports.list = () => {
     if(!config.has('plugins'))


### PR DESCRIPTION
_fix_ ( **pluginloader.js** ) : serialize npm commands in test plugin flows

Ensure npm commands in addTest and removeTest run sequentially. Previously, multiple exec calls were fired in parallel, causing npm link/install (and rm/uninstall) to overlap and fail on Windows with EPERM or file-lock errors.

**Using async/await makes the process deterministic and stable.**
#308 