### PR TITLE
Respect deviating resource data path when hostProject setting is used

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -131,10 +131,9 @@ module.exports.bundleApp = async (options = {}) => {
 
         await createAsarFile();
         utils.log('Copying binaries...');
-
-        const resourceData = fse.readFileSync(
-          `${buildDir}/${binaryName}/${constants.files.resourceFile}`,
-        );
+        
+        const resourcePath = hostproject.hasHostProject() ? `${buildDir}/${binaryName}/bin/${constants.files.resourceFile}` : `${buildDir}/${binaryName}/${constants.files.resourceFile}`;
+        const resourceData = fse.readFileSync(resourcePath);
 
         for (let platform in constants.files.binaries) {
             for (let arch in constants.files.binaries[platform]) {


### PR DESCRIPTION
Respect deviating resource data path when hostProject setting is used

When cli.hostProject setting is used the resouce file is created in subfolder /bin/. This was not considered when reading the resource file during bundling.

Fixes #310 
