### PR TITLE
skip patching html file if cli.frontendLibrary.patchFile is empty

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -31,7 +31,7 @@ module.exports.register = (program) => {
             let argsOpt = "";
 
             websocket.start({
-                frontendLibDev: containsFrontendLibApp
+                frontendLibDev: containsFrontendLibApp && configObj.cli.frontendLibrary.patchFile
             });
             
             if(containsFrontendLibApp) {


### PR DESCRIPTION
If globals are injected via modes.window.injectGlobals = true and the client library is either loaded via 
modes.window.injectClientLibrary or included and bundled from npm module import, there is no need to patch the html file during `neu run`.

This patch skips the modification and restoration of the html file if cli.frontendLibrary.patchFile is undefined or empty.

closes #296