### PR TITLE
Improving Error hitting on neu create without binaryName

### DIFF
--- a/bin/neu.js
+++ b/bin/neu.js
@@ -5,6 +5,10 @@ const neu = require('../src/neu-cli');
 const utils = require('../src/utils');
 
 const program = new Command();
+program
+  .showHelpAfterError()
+  .showSuggestionAfterError(true);
+
 neu.bootstrap(program);
 
 program.addHelpText('beforeAll', utils.getFiglet());

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@electron/asar": "^3.0.3",
     "chalk": "^4.1.0",
     "chokidar": "^4.0.3",
-    "commander": "^7.2.0",
+    "commander": "^9.5.0",
     "configstore": "^5.0.1",
     "edit-json-file": "^1.6.2",
     "follow-redirects": "^1.13.1",

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -2,13 +2,19 @@ const creator = require('../modules/creator');
 const utils = require('../utils');
 
 module.exports.register = (program) => {
-    program
-        .command('create <binaryName>')
-        .description('creates an app based on template (neutralinojs/neutralinojs-minimal by default)')
-        .option('-t, --template [template]')
-        .action(async (binaryName, command) => {
-            await creator.createApp(binaryName, command.template);
-            utils.showArt();
-        });
+   program
+  .command('create <binaryName>')
+  .description('creates an app based on template (neutralinojs/neutralinojs-minimal by default)')
+  .option('-t, --template [template]')
+  .addHelpText('after', `
+Examples:
+  neu create my_app
+  neu create my_app --template neutralinojs/neutralinojs-minimal
+`)
+  .action(async (binaryName, command) => {
+      await creator.createApp(binaryName, command.template);
+      utils.showArt();
+  });
+
 }
 


### PR DESCRIPTION
This PR upgrades `commander` to a modern stable version in order to
enable improved error handling across the CLI specially for the `neu create` CMD.

With this change, the CLI now:
- Shows help output after argument errors
- Provides command suggestions for unknown commands
- Improves onboarding UX for commands like `neu create`

All existing tests pass, and no CLI behavior is changed aside from
error messaging improvements.

Fixes Issue- #315 
<img width="1400" height="573" alt="image" src="https://github.com/user-attachments/assets/9c24bd9b-7929-4413-bf16-43b9baa79296" />
