### PR TITLE
#319  Fix/version command hang

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -47,9 +47,12 @@ let checkCurrentProject = () => {
 
 let checkLatestVersion = () => {
     return new Promise((resolve) => {
-        exec(`npm view ${package.name} version`, (err, versionInfo) => {
-            let latestVersion = versionInfo.trim();
-            if (!err && package.version !== latestVersion) {
+        exec(`npm view ${package.name} version`, { timeout: 4000 }, (err, versionInfo) => {
+            if (err) {   
+                return resolve(true);
+            }
+            let latestVersion = versionInfo ? versionInfo.trim() : null;
+            if (latestVersion && package.version !== latestVersion) {
                 warn(`You are using an older neu CLI version. Install the latest version ` +
                     `by entering 'npm install -g ${package.name}'`);
                 resolve(false);
@@ -58,7 +61,6 @@ let checkLatestVersion = () => {
         });
     });
 }
-
 
 let log = (message) => {
     console.log(`neu: ${chalk.bgGreen.black('INFO')} ${message}`);


### PR DESCRIPTION
#319

This PR fixes a bug where neu version hangs indefinitely in offline environments. I implemented 4s/5s timeouts for the npm view and https.get requests to ensure the CLI remains responsive. Tested locally by running the command without internet connectivity