### PR TITLE
#327 optimize websocket polling with adaptive backoff and timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects


### PR DESCRIPTION
#327 
Improved the WebSocket reconnection logic in the CLI. Instead of a hardcoded 1-second delay, it now uses an adaptive backoff starting at 200ms and capping at 1000ms. This makes app reconnections feel much snappier during development.

Also added a MAX_RETRIES limit to prevent the CLI from polling indefinitely if the runtime fails to start.

