### PR TITLE
feat: add --binary and --client flags for selective updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -5,12 +5,19 @@ module.exports.register = (program) => {
     program
         .command('update')
         .description('updates neutralinojs binaries, client library, and TypeScript definitions')
-        .option('-l, --latest')
+        .option('-l, --latest', 'fetches the latest version details and updates the app configuration')
+        .option('-b, --binary', 'updates only the neutralinojs binaries')
+        .option('-c, --client', 'updates only the neutralinojs client library') 
         .action(async (command) => {
             utils.checkCurrentProject();
-            await downloader.downloadAndUpdateBinaries(command.latest);
-            await downloader.downloadAndUpdateClient(command.latest);
+            const updateAll = !command.binary && !command.client;
 
+            if (updateAll || command.binary) {
+            await downloader.downloadAndUpdateBinaries(command.latest);
+            }
+            if (updateAll || command.client) {
+            await downloader.downloadAndUpdateClient(command.latest);
+            }
             utils.showArt();
             utils.log('Run "neu version" to see installed version details.');
         });


### PR DESCRIPTION
#329

Right now, running neu update forces a download of everything (binaries, client library, and types). This is a bit of a waste of time and bandwidth if you only need to refresh the JS client or if you just want to update the binaries.

I have added two optional flags to make the update process more flexible:
--binary (-b): Only updates the Neutralino binaries.
--client (-c): Only updates the neutralino.js file and types.

If you don't use any flags, it still updates everything exactly like before, so it won't break anyone's current workflow.
What I changed:
Modified src/commands/update.js to handle these new options using the existing commander setup.
