### PR TITLE
feat: enhance build and version commands for better CI/CD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -13,6 +13,8 @@ module.exports.register = (program) => {
         .option('--copy-storage')
         .option('--clean')
         .option('--macos-bundle')
+        .option('--plan', 'preview build process without executing')
+        .option('--platform <platform>', 'target specific platform (windows, linux, mac)')
         .action(async (command) => {
             if(command.configFile) {
               utils.log(`Using config file: ${command.configFile}`);
@@ -20,22 +22,34 @@ module.exports.register = (program) => {
             }
 
             utils.checkCurrentProject();
-            const configObj = config.get()
+            const configObj = config.get();
             const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
+
+            if (command.plan) {
+                utils.log('--- Build Plan ---');
+                utils.log(`Distribution Path: ${buildDir}`);
+                utils.log(`Release Mode: ${command.release ? 'Yes' : 'No'}`);
+                utils.log(`Target Platform: ${command.platform || 'all'}`);
+                utils.log(`Embed Resources: ${command.embedResources ? 'Yes' : 'No'}`);
+                return;
+            }
+
             if(command.clean) {
                 utils.log(`Cleaning previous build files from ${buildDir}...`);
                 utils.clearDirectory(buildDir);
             }
+
             utils.log('Bundling app...');
             await bundler.bundleApp({
-                release: command.release, 
+                release: command.release,
                 embedResources: command.embedResources,
                 copyStorage: command.copyStorage,
-                macosBundle: command.macosBundle
+                macosBundle: command.macosBundle,
+                platform: command.platform
             });
+
             utils.showArt();
             utils.log(`Application package was generated at the ${buildDir} directory!`);
             utils.log('Distribution guide: https://neutralino.js.org/docs/distribution/overview');
         });
 }
-

--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -7,38 +7,72 @@ module.exports.register = (program) => {
     program
         .command('version')
         .description('displays global and project specific versions of packages')
-        .action(async (command) => {
-            utils.showArt();
-            console.log('--- Global ---');
+        .option('--json', 'output in JSON format')
+        .option('--health', 'check environment health and project readiness')
+        .action(async (options) => {
             const latest = await utils.checkLatestVersion();
-            console.log(`neu CLI: v${package.version} ${latest ? '(latest)' : ''}`);
-            if(utils.isNeutralinojsProject()) {
+            let versionData = {
+                global: {
+                    neuCli: `v${package.version}`,
+                    isLatest: latest
+                }
+            };
+
+            if (utils.isNeutralinojsProject()) {
                 const configObj = config.get();
                 const latestBinVersion = await getRemoteLatestVersion('neutralinojs');
                 const latestLibVersion = await getRemoteLatestVersion('neutralino.js');
+
                 const clientVersion = configObj.cli.clientVersion ? utils.getVersionTag(configObj.cli.clientVersion) :
-                        'Installed from a package manager';
+                                        'Installed from a package manager';
                 const latestBin = configObj.cli.binaryVersion == latestBinVersion;
                 const latestLib = configObj.cli.clientVersion ? (configObj.cli.clientVersion == latestLibVersion) : null;
 
-                console.log(`\n--- Project: ${configObj.cli.binaryName} (${configObj.applicationId}) ---`);
-                console.log(`Neutralinojs binaries: ${utils.getVersionTag(configObj.cli.binaryVersion)} ${latestBin ? '(latest)' : ''}`);
-                console.log(`Neutralinojs client: ${clientVersion} ${latestLib ? '(latest)' : ''}`);
+                versionData.project = {
+                    binaryName: configObj.cli.binaryName,
+                    applicationId: configObj.applicationId,
+                    binaryVersion: utils.getVersionTag(configObj.cli.binaryVersion),
+                    clientVersion: clientVersion,
+                    isBinaryLatest: latestBin,
+                    isClientLatest: latestLib,
+                    projectVersion: configObj.version || null
+                };
+            }
 
-                if(!latestBin || latestLib === false) {
+            if (options.json) {
+                console.log(JSON.stringify(versionData, null, 2));
+                return;
+            }
+
+            utils.showArt();
+            console.log('--- Global ---');
+            console.log(`neu CLI: v${package.version} ${latest ? '(latest)' : ''}`);
+
+            if (versionData.project) {
+                const p = versionData.project;
+                console.log(`\n--- Project: ${p.binaryName} (${p.applicationId}) ---`);
+                console.log(`Neutralinojs binaries: ${p.binaryVersion} ${p.isBinaryLatest ? '(latest)' : ''}`);
+                console.log(`Neutralinojs client: ${p.clientVersion} ${p.isClientLatest ? '(latest)' : ''}`);
+
+                if (!p.isBinaryLatest || p.isClientLatest === false) {
                     utils.warn(`This project doesn't use the latest Neutralinojs framework. Run ` +
                         `'neu update --latest' to download the latest framework binaries and the client library.`);
                 }
 
-                if(configObj.version) {
-                    console.log(`Project version: v${configObj.version}`);
+                if (p.projectVersion) {
+                    console.log(`Project version: v${p.projectVersion}`);
                 }
-
+            } else {
+                utils.log(`Run this command inside your project directory to get project specific Neutralinojs version.`);
             }
-            else {
-                utils.log(`Run this command inside your project directory` +
-                            ` to get project specific Neutralinojs version.`);
+
+            if (options.health) {
+                console.log(`\n--- Health Check ---`);
+                const isProject = !!versionData.project;
+                console.log(`Neutralino Project: ${isProject ? '✅ Yes' : '❌ No'}`);
+                if (isProject) {
+                    console.log(`Version Drift: ${(!versionData.project.isBinaryLatest) ? '⚠️ Outdated' : '✅ Up to date'}`);
+                }
             }
         });
 }
-

--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -8,7 +8,6 @@ const frontendlib = require('./frontendlib');
 const hostproject = require('./hostproject');
 const utils = require('../utils');
 const {patchWindowsExecutable} = require('./exepatch');
-const path = require('path');
 const {inject} = require('postject');
 
 async function createAsarFile() {
@@ -42,7 +41,7 @@ async function createAsarFile() {
     }
 
     await fse.copy(`${constants.files.configFile}`, `.tmp/neutralino.config.json`, { overwrite: true });
-    
+
     if (clientLibrary) {
         let typesFile = clientLibrary.replace(/.js$/, '.d.ts');
         await fse.copy(`./${clientLibrary}`, `.tmp/${clientLibrary}`, { overwrite: true });
@@ -120,6 +119,12 @@ module.exports.bundleApp = async (options = {}) => {
     const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
     const hostProjectConfig = configObj.cli ? configObj.cli.hostProject : undefined;
 
+    const platformMap = {
+        'linux': 'linux',
+        'windows': 'win32',
+        'mac': 'darwin'
+    };
+
     try {
         if (frontendlib.containsFrontendLibApp()) {
             await frontendlib.runCommand('buildCommand');
@@ -131,15 +136,21 @@ module.exports.bundleApp = async (options = {}) => {
 
         await createAsarFile();
         utils.log('Copying binaries...');
-        
+
         const resourcePath = hostproject.hasHostProject() ? `${buildDir}/${binaryName}/bin/${constants.files.resourceFile}` : `${buildDir}/${binaryName}/${constants.files.resourceFile}`;
         const resourceData = fse.readFileSync(resourcePath);
 
-        for (let platform in constants.files.binaries) {
+        let targetPlatforms = Object.keys(constants.files.binaries);
+        if (options.platform && platformMap[options.platform]) {
+            targetPlatforms = [platformMap[options.platform]];
+        }
+
+        for (let platform of targetPlatforms) {
             for (let arch in constants.files.binaries[platform]) {
                 let originalBinaryFile = constants.files.binaries[platform][arch];
                 let destinationBinaryFile = hostproject.hasHostProject() ? `bin/${originalBinaryFile}` : originalBinaryFile.replace('neutralino', binaryName);
                 let destinationFullPath = `${buildDir}/${binaryName}/${destinationBinaryFile}`;
+
                 if (fse.existsSync(`bin/${originalBinaryFile}`)) {
                     fse.copySync(`bin/${originalBinaryFile}`, destinationFullPath);
                     if (options.embedResources) {
@@ -163,21 +174,23 @@ module.exports.bundleApp = async (options = {}) => {
             }
         }
 
-        utils.log('Patching windows executables...');
-        try {
-            await Promise.all(Object.keys(constants.files.binaries.win32).map(async (arch) => {
-                const origBinaryName = constants.files.binaries.win32[arch];
-                const filepath = hostproject.hasHostProject() ? `bin/${origBinaryName}` : origBinaryName.replace('neutralino', binaryName);
-                const winPath = `${buildDir}/${binaryName}/${filepath}`;
-                if (await fse.exists(winPath)) {
-                    await patchWindowsExecutable(winPath);
-                }
-            }))
-        }
-        catch (err) {
-            console.error(err);
-            utils.error('Could not patch windows executable');
-            process.exit(1);
+        if (!options.platform || options.platform === 'windows') {
+            utils.log('Patching windows executables...');
+            try {
+                await Promise.all(Object.keys(constants.files.binaries.win32).map(async (arch) => {
+                    const origBinaryName = constants.files.binaries.win32[arch];
+                    const filepath = hostproject.hasHostProject() ? `bin/${origBinaryName}` : origBinaryName.replace('neutralino', binaryName);
+                    const winPath = `${buildDir}/${binaryName}/${filepath}`;
+                    if (await fse.exists(winPath)) {
+                        await patchWindowsExecutable(winPath);
+                    }
+                }))
+            }
+            catch (err) {
+                console.error(err);
+                utils.error('Could not patch windows executable');
+                process.exit(1);
+            }
         }
 
         for (let dependency of constants.files.dependencies) {
@@ -208,11 +221,14 @@ module.exports.bundleApp = async (options = {}) => {
             }
         }
 
-        if(options.macosBundle){
+        if (options.macosBundle && (!options.platform || options.platform === 'mac')) {
             utils.log('Creating MacOS app bundles...');
             for(let macBinary of Object.values(constants.files.binaries.darwin)) {
                 macBinary = hostproject.hasHostProject() ? `bin/${macBinary}` : macBinary.replace('neutralino', binaryName);
-                fs.renameSync(`${buildDir}/${binaryName}/${macBinary}`, `${buildDir}/${binaryName}/${macBinary}.app`);
+                const macAppPath = `${buildDir}/${binaryName}/${macBinary}`;
+                if (fse.existsSync(macAppPath)) {
+                    fs.renameSync(macAppPath, `${macAppPath}.app`);
+                }
             }
         }
 
@@ -220,10 +236,13 @@ module.exports.bundleApp = async (options = {}) => {
             utils.log('Making app bundle ZIP file...');
             await zl.archiveFolder(`${buildDir}/${binaryName}`, `${buildDir}/${binaryName}-release.zip`);
         }
-      
+
         utils.clearDirectory('.tmp');
         if (options.embedResources) {
-            utils.clearDirectory(`${buildDir}/${binaryName}/${constants.files.resourceFile}`);
+            const resourceFileInDist = `${buildDir}/${binaryName}/${constants.files.resourceFile}`;
+            if (fse.existsSync(resourceFileInDist)) {
+                fse.removeSync(resourceFileInDist);
+            }
         }
     }
     catch (e) {


### PR DESCRIPTION
## Description
This PR implements the improvements proposed in #325 to make the `neu` CLI more robust for professional workflows and CI/CD pipelines. It introduces machine-readable outputs and precise control over the build process.

## Changes

### `neu build` improvements:
* **Platform Targeting**: Added `--platform` flag (`windows`, `linux`, `mac`) to build only specific targets. This prevents unnecessary bundling for unused platforms and speeds up CI pipelines.
* **Plan Mode**: Added `--plan` flag to preview the build configuration (distribution path, release mode, targets) without executing the actual bundling process.

### `neu version` improvements:
* **JSON Output**: Added `--json` flag for machine-readable version information, allowing automation tools to parse CLI and project versions easily.
* **Health Check**: Added `--health` flag to verify environment readiness and detect version drift between the CLI and the project binaries.

## Impact
These changes are **backward-compatible**. The CLI maintains its existing human-readable behavior by default, but gives power users and automation scripts much more control and transparency.

## Technical Notes
* Refactored `src/modules/bundler.js` to support conditional execution of patching and bundling logic.
* Added a `platformMap` to bridge CLI flags with internal platform constants (`win32`, `darwin`, `linux`).
* Implemented a dry-run return in `src/commands/build.js` for the plan mode.

## Testing
- Verified `node bin/neu.js version --json` returns valid JSON data.
- Verified `node bin/neu.js build --plan --platform windows` correctly previews the build without creating files.
- Confirmed that the CLI still checks for `neutralino.config.json` before execution.

Fixes #325