### PR TITLE
Docs: Add usage examples to 'neu help create' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -6,9 +6,13 @@ module.exports.register = (program) => {
         .command('create <binaryName>')
         .description('creates an app based on template (neutralinojs/neutralinojs-minimal by default)')
         .option('-t, --template [template]')
+				.addHelpText('after', `
+Examples:
+  $ neu create myapp
+  $ neu create myapp --template neutralinojs/neutralinojs-zero
+        `)
         .action(async (binaryName, command) => {
             await creator.createApp(binaryName, command.template);
             utils.showArt();
         });
 }
-


### PR DESCRIPTION
## Description
This PR resolves #334 by adding a "Examples" section to the `neu help create` command output.

### Problem
New users often find it unclear how to use the `--template` flag, sometimes attempting to provide full URLs instead of the required `username/repo` format. The current help output only lists options without demonstrating their usage.

### Solution
Using Commander's `.addHelpText` method, I've added a concise examples section that shows:
1. Basic project creation.
2. Creation using a custom template.

### Impact
Improves the developer onboarding experience and reduces common mistakes when using the CLI for the first time.

Fixes #334