### PR TITLE
replaced bitwise operator with logical OR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -114,7 +114,7 @@ module.exports.containsFrontendLibApp = () => {
 module.exports.waitForFrontendLibApp = async () => {
     let configObj = config.get();
     let devUrlString = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.devUrl : undefined;
-    let timeout = configObj.cli && configObj.cli.frontendLibrary && configObj.cli.frontendLibrary.waitTimeout | 20000;
+    let timeout = configObj.cli?.frontendLibrary?.waitTimeout ?? 20000;
     let url = new URL(devUrlString);
     let portString = url.port;
     let port = portString ? Number.parseInt(portString) : getPortByProtocol(url.protocol)


### PR DESCRIPTION
Fixes #337 

## Description

Fixes incorrect behavior of `cli.frontendLibrary.waitTimeout`: the config value was being combined with the default via **bitwise OR** (`|`) instead of using the configured value or falling back to the default. This change uses nullish coalescing (`??`) and optional chaining (`?.`) so the configured timeout is respected and the default is only used when the value is missing.

### Problem

In `src/modules/frontendlib.js`, the timeout was computed as:

```javascript
let timeout = configObj.cli && configObj.cli.frontendLibrary && configObj.cli.frontendLibrary.waitTimeout | 20000;
```

Because of operator precedence this is `(… && waitTimeout) | 20000`. So:

- **Unset** → `undefined | 20000` → 20000 ✓ (by accident)
- **Set to 5000** → `5000 | 20000` → 24104 ✗
- **Set to 30000** → `30000 | 20000` → 32760 ✗

### Solution

Use optional chaining and nullish coalescing so we either use the config value or the default when it’s `null`/`undefined`:

```javascript
let timeout = configObj.cli?.frontendLibrary?.waitTimeout ?? 20000;
```

- **Unset / null** → 20000 ms (default)
- **Set to any number (e.g. 5000, 0)** → that number is used

---

