### PR TITLE
Improve template validation and error messaging in neu create command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -6,6 +6,11 @@ module.exports.register = (program) => {
         .command('create <binaryName>')
         .description('creates an app based on template (neutralinojs/neutralinojs-minimal by default)')
         .option('-t, --template [template]')
+        .addHelpText('after', `
+Examples:
+  $ neu create myapp
+  $ neu create myapp --template username/repository-name
+`)
         .action(async (binaryName, command) => {
             await creator.createApp(binaryName, command.template);
             utils.showArt();

--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -19,12 +19,29 @@ module.exports.createApp = async (appPath, template) => {
     if(!template) {
         template = 'neutralinojs/neutralinojs-minimal';
     }
+    if (
+        template.includes("http") ||
+        template.includes("github.com") ||
+        template.split('/').length !== 2
+    ) {
+    utils.error(`
+Invalid template format.
+
+Expected format:username/repository
+Example:neutralinojs/neutralinojs-zero
+
+`);
+    process.exit(1);
+}
 
     utils.log(`Checking if ${template} is a valid Neutralinojs app template...`);
 
     const isValidTemplate = await downloader.isValidTemplate(template);
     if(!isValidTemplate) {
-        utils.error(`${template} is not a valid Neutralinojs app template.`);
+        utils.error(`${template} is not a valid Neutralinojs app template.
+The repository must contain a 'neutralino.config.json' file at the root level.            
+            
+            `);
         process.exit(1);
     }
 


### PR DESCRIPTION
## Summary

This PR improves the developer experience of the `neu create` command by:

- Adding format validation for template input (expected: username/repository)
- Providing clearer error messaging when:
  - A full GitHub URL is used
  - The template format is invalid
  - The repository does not contain `neutralino.config.json`

## Why

Previously, the CLI only displayed a generic "not a valid template" error.
This change provides actionable guidance and prevents unnecessary API calls for clearly invalid formats.

## Tested Cases

- Full GitHub URL (https://github.com/user/repo)
- Missing slash (user)
- Extra segments (user/repo/extra)
- Valid but non-template repo
- Valid template repo