### PR TITLE
version loading even without the internet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,14 +47,30 @@ let checkCurrentProject = () => {
 
 let checkLatestVersion = () => {
     return new Promise((resolve) => {
+        const timeoutMs = 8000;
+        let resolved = false;
+        const doResolve = (value) => {
+            if (!resolved) {
+                resolved = true;
+                resolve(value);
+            }
+        };
+        const timer = setTimeout(() => doResolve(true), timeoutMs);
         exec(`npm view ${package.name} version`, (err, versionInfo) => {
-            let latestVersion = versionInfo.trim();
-            if (!err && package.version !== latestVersion) {
+            if (resolved) return;
+            clearTimeout(timer);
+            if (err) {
+                doResolve(true);
+                return;
+            }
+            let latestVersion = (versionInfo && typeof versionInfo === 'string') ? versionInfo.trim() : '';
+            if (latestVersion && package.version !== latestVersion) {
                 warn(`You are using an older neu CLI version. Install the latest version ` +
                     `by entering 'npm install -g ${package.name}'`);
-                resolve(false);
+                doResolve(false);
+            } else {
+                doResolve(true);
             }
-            resolve(true);
         });
     });
 }


### PR DESCRIPTION
Fixes #342 
Fixes crash and hang in neu version when offline or npm view fails.
Prevents .trim() on undefined (versionInfo safely checked).
Resolves immediately on exec error.
Adds 8s timeout to avoid hanging.
Ensures promise resolves only once.

https://github.com/user-attachments/assets/47b92129-4208-43c6-8fab-c866f0f4a18c



