### PR TITLE
Improve error guidance when running neu create without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,5 +1,5 @@
 program
-  .command('create <binaryName>')
+  .command('create [binaryName]')
   .description('creates an app based on template (neutralinojs/neutralinojs-...)')
   .option('-t, --template [template]')
   .addHelpText('after', `
@@ -8,6 +8,12 @@ Examples:
   $ neu create myapp --template neutralinojs/neutralinojs-zero
 `)
   .action(async (binaryName, command) => {
-    await creator.createApp(binaryName, command.template);
-    utils.showArt();
-  });
+  if (!binaryName) {
+    console.log('\nUsage:\n  neu create <binaryName>\n');
+    console.log('Example:\n  neu create my_app\n');
+    process.exit(1);
+  }
+
+  await creator.createApp(binaryName, command.template);
+  utils.showArt();
+});

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,14 +1,13 @@
-const creator = require('../modules/creator');
-const utils = require('../utils');
-
-module.exports.register = (program) => {
-    program
-        .command('create <binaryName>')
-        .description('creates an app based on template (neutralinojs/neutralinojs-minimal by default)')
-        .option('-t, --template [template]')
-        .action(async (binaryName, command) => {
-            await creator.createApp(binaryName, command.template);
-            utils.showArt();
-        });
-}
-
+program
+  .command('create <binaryName>')
+  .description('creates an app based on template (neutralinojs/neutralinojs-...)')
+  .option('-t, --template [template]')
+  .addHelpText('after', `
+Examples:
+  $ neu create myapp
+  $ neu create myapp --template neutralinojs/neutralinojs-zero
+`)
+  .action(async (binaryName, command) => {
+    await creator.createApp(binaryName, command.template);
+    utils.showArt();
+  });


### PR DESCRIPTION
This PR improves the error guidance when running `neu create` without providing a binaryName.

Instead of showing the default Commander error:

  error: missing required argument 'binaryName'

It now displays clear usage instructions and an example:

Usage:
  neu create <binaryName>

Example:
  neu create my_app

Closes #315