### PR TITLE
Improve CLI error message when running outside a Neutralino project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,13 +34,18 @@ let showArt = () => {
 
 let checkCurrentProject = () => {
     if (!isNeutralinojsProject()) {
-        error(`Unable to find ${CONFIG_FILE}. ` +
-            `Please check whether the current directory has a Neutralinojs project.`);
+        error(
+            `This command must be run inside Neutralino project.\n` +
+            `${CONFIG_FILE} file not found in this directory.\n` +
+            `If you have not created a project yet, run:\n` +
+            `  neu create <app-name>`
+        );
         process.exit(1);
     }
-    const configObj =  config.get();
-    if(Object.keys(configObj).length == 0) {
-        error(`${CONFIG_FILE} is not a valid Neutralinojs configuration JSON file.`);
+
+    const configObj = config.get();
+    if (Object.keys(configObj).length === 0) {
+        error(`${CONFIG_FILE} is not a valid Neutralino configuration file.`);
         process.exit(1);
     }
 }


### PR DESCRIPTION


Improved the CLI error message shown when a command is executed outside a Neutralino project directory.

Why?

The previous message was not very clear. This update explains that neutralino.config.json is required and suggests running neu create <app-name> if a project has not been created.
Fixes #346 