### PR TITLE
fix: add safety check for distributionPath to prevent data loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -2,6 +2,7 @@ const utils = require('../utils');
 const bundler = require('../modules/bundler');
 const config = require('../modules/config');
 const constants = require('../constants');
+const path = require('path');
 
 module.exports.register = (program) => {
     program
@@ -14,28 +15,58 @@ module.exports.register = (program) => {
         .option('--clean')
         .option('--macos-bundle')
         .action(async (command) => {
-            if(command.configFile) {
-              utils.log(`Using config file: ${command.configFile}`);
-              constants.files.configFile = command.configFile;
-            }
+    if (command.configFile) {
+        utils.log(`Using config file: ${command.configFile}`);
+        constants.files.configFile = command.configFile;
+    }
 
-            utils.checkCurrentProject();
-            const configObj = config.get()
-            const buildDir = configObj.cli.distributionPath ? utils.trimPath(configObj.cli.distributionPath) : 'dist';
-            if(command.clean) {
-                utils.log(`Cleaning previous build files from ${buildDir}...`);
-                utils.clearDirectory(buildDir);
-            }
-            utils.log('Bundling app...');
-            await bundler.bundleApp({
-                release: command.release, 
-                embedResources: command.embedResources,
-                copyStorage: command.copyStorage,
-                macosBundle: command.macosBundle
-            });
-            utils.showArt();
-            utils.log(`Application package was generated at the ${buildDir} directory!`);
-            utils.log('Distribution guide: https://neutralino.js.org/docs/distribution/overview');
-        });
+    utils.checkCurrentProject();
+
+    const configObj = config.get();
+    const projectRoot = process.cwd();
+
+    let buildDir = 'dist';
+    if (configObj.cli && typeof configObj.cli.distributionPath === 'string') {
+        buildDir = utils.trimPath(configObj.cli.distributionPath);
+    }
+
+    if (typeof buildDir !== 'string' || buildDir.trim() === '') {
+        throw new Error('Invalid distributionPath: must be a non-empty string.');
+    }
+
+    const absoluteBuildDir = path.resolve(projectRoot, buildDir);
+
+    // Prevent using project root as build directory
+    if (absoluteBuildDir === projectRoot) {
+        throw new Error(
+            `Invalid distributionPath: "${buildDir}". It cannot be the project root.`
+        );
+    }
+
+    // Prevent paths outside the project directory
+    const relativePath = path.relative(projectRoot, absoluteBuildDir);
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        throw new Error(
+            `Invalid distributionPath: "${buildDir}". It must be inside the project folder.`
+        );
+    }
+
+    if (command.clean) {
+        utils.log(`Cleaning previous build files from ${buildDir}...`);
+        utils.clearDirectory(absoluteBuildDir);
+    }
+
+    utils.log('Bundling app...');
+
+    await bundler.bundleApp({
+        release: command.release,
+        embedResources: command.embedResources,
+        copyStorage: command.copyStorage,
+        macosBundle: command.macosBundle
+    });
+
+    utils.showArt();
+    utils.log(`Application package was generated at the ${buildDir} directory!`);
+    utils.log('Distribution guide: https://neutralino.js.org/docs/distribution/overview');
+});
 }
-


### PR DESCRIPTION
I noticed that if someone accidentally sets distributionPath to . or ../ in their config, running neu build --clean will actually delete their whole project or files outside the folder.

This PR adds a safety check to stop the build if the path is dangerous. It uses path.resolve and path.relative to make sure the build folder is always inside the project and isn't the root directory itself.

Tests done:

dist:  Works fine.
"." (Root):  Blocked. (Error: It cannot be the project root)
"../" (Outside):  Blocked. (Error: It must be inside the project folder)