### PR TITLE
feat(run): add --browser flag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ the next release. Once the changes are released,
 rename `Unreleased` topic with the new version tag. Finally, create a new `Unreleased` topic for future changes.
 
 ## Unreleased
-
-## v11.7.0
+### Features
+- Add `--browser` flag support to the run command
 
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -19,6 +19,7 @@ module.exports.register = (program) => {
         .description('fetches config from neutralino.config.json & runs the app')
         .option('--disable-auto-reload')
         .option('--arch <arch>')
+        .option('--browser')
         .action(async (command) => {
             utils.checkCurrentProject();
             let configObj = config.get();
@@ -55,6 +56,10 @@ module.exports.register = (program) => {
 
             if(containsFrontendLibApp && configObj.cli.frontendLibrary.devUrl) {
                 argsOpt += ` --url=${configObj.cli.frontendLibrary.devUrl}`
+            }
+            
+            if(command.browser) {
+                argsOpt += " --mode=browser";
             }
 
             try {


### PR DESCRIPTION
This PR adds support for a new --browser flag to the run command.


Changes:

Added --browser option to run command
Append --mode=browser when flag is present
Updated CHANGELOG under Unreleased
Fixes #354