### PR TITLE
docs: add local development setup guide to CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+## v11.7.0
+
 ### Bugfixes/improvements
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,59 @@ The following is a set of guidelines for contributing to neutralinojs-cli, which
 ## Table Of Contents
 
 - [Code of Conduct](#code-of-conduct)
+- [Local Development](#local-development)
 - [Making a PR](#making-a-pr)
 
 ## Code of Conduct
 
 This project encourages each and everyone to contribute to it. By participating, you are expected to uphold the spirits of open source culture.
+
+## Local Development
+
+Follow these steps to set up the project locally for development:
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/neutralinojs/neutralinojs-cli.git
+cd neutralinojs-cli
+```
+
+### 2. Install dependencies
+
+```bash
+npm install
+```
+
+### 3. Build the CLI
+
+The source code needs to be compiled before running the CLI
+
+```bash
+npm run build
+```
+
+### 4. Run the CLI locally
+
+You can run the generated CLI directly using Node.js:
+
+```bash
+node ./bin/neu.js --help
+```
+
+Or link it globally to use the neu command system-wide during development:
+
+```bash
+npm link
+neu --version
+```
+
+### Useful Scripts
+
+- `npm start`: Runs the CLI using the entry point.
+- `npm run build`: Compiles the source code into the `./bin` directory.
+- `npm test`: Runs the Mocha test suite to ensure stability.
+- `npm run lint`: Checks the code for style and formatting issues.
 
 ## Making a PR
 


### PR DESCRIPTION
### Description
The current `CONTRIBUTING.md` lacks instructions on how to set up the project locally. This PR adds a "Local Development" section to help new contributors get started.

### Changes
- Added a "Local Development" section to `CONTRIBUTING.md`.
- Included steps for: cloning, installing dependencies, building, and running the CLI.
- Documented useful npm scripts (`start`, `build`, `test`, `lint`).
- Updated the Table of Contents for better navigation.

### Testing
Verified the instructions by performing a clean install and build on my local machine.

Closes #360