### PR TITLE
Add Quick Start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,30 @@
 The official CLI of Neutralinojs. See neu CLI [documentation](https://neutralino.js.org/docs/cli/neu-cli/) for more details. Release notes are available at [this page](https://neutralino.js.org/docs/release-notes/cli).
 
 ```bash
-npm i -g @neutralinojs/neu
+npm install -g @neutralinojs/neu
 ```
+
+## Quick Start
+
+Create a new Neutralinojs application:
+
+```bash
+neu create myApp
+cd myApp
+```
+
+Run the application:
+
+```bash
+neu run
+```
+
+Build the application:
+
+```bash
+neu build
+```
+
 ### Requirements
 
 - Node.js v12 or later version.
@@ -25,6 +47,7 @@ npm i -g @neutralinojs/neu
 We really appreciate your code contributions. Please read [this contribution guide](https://neutralino.js.org/docs/contributing/framework-developer-guide#contribution-guidelines) before sending a pull request. Thank you for your contributions.
 
 #### ⚠️ Notice for contributors
+
 Please note that we would like to keep this project's dependencies list minimal as possible. Make sure that you don't add new dependencies (external `npm` modules) with your pull requests. Also, don't use latest Node/JavaScript features that won't work on older Node.js versions. Thank you :tada:
 
 ### Contributors

--- a/README.md
+++ b/README.md
@@ -1,59 +1,158 @@
-<div align="center"><img src="images/logo.png"/></div>
+<div align="center">
+  <img src="images/logo.png" alt="Neutralinojs Logo"/>
+</div>
 
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/neutralinojs/neutralinojs-cli)](https://github.com/neutralinojs/neutralinojs-cli/releases)
-![npm](https://img.shields.io/npm/v/@neutralinojs/neu)
-![npm](https://img.shields.io/npm/dt/@neutralinojs/neu)
-[![GitHub last commit](https://img.shields.io/github/last-commit/neutralinojs/neutralinojs-cli.svg)](https://github.com/neutralinojs/neutralinojs-cli/commits/main)
-![Build status](https://github.com/neutralinojs/neutralinojs-cli/actions/workflows/test_suite.yml/badge.svg)
+<br/>
 
-The official CLI of Neutralinojs. See neu CLI [documentation](https://neutralino.js.org/docs/cli/neu-cli/) for more details. Release notes are available at [this page](https://neutralino.js.org/docs/release-notes/cli).
+<p align="center">
+  <b>The official CLI for building lightweight desktop apps with Neutralinojs</b>
+</p>
+
+<p align="center">
+  <a href="https://github.com/neutralinojs/neutralinojs-cli/releases">
+    <img src="https://img.shields.io/github/v/release/neutralinojs/neutralinojs-cli" />
+  </a>
+  <img src="https://img.shields.io/npm/v/@neutralinojs/neu" />
+  <img src="https://img.shields.io/npm/dt/@neutralinojs/neu" />
+  <a href="https://github.com/neutralinojs/neutralinojs-cli/commits/main">
+    <img src="https://img.shields.io/github/last-commit/neutralinojs/neutralinojs-cli.svg" />
+  </a>
+  <img src="https://github.com/neutralinojs/neutralinojs-cli/actions/workflows/test_suite.yml/badge.svg" />
+</p>
+
+---
+
+## 📦 About
+
+`neu` is the official CLI tool for Neutralinojs — a lightweight and portable framework for building cross-platform desktop applications using web technologies like HTML, CSS, and JavaScript.
+
+It helps developers quickly scaffold, run, and build Neutralinojs applications with minimal setup and dependencies.
+
+---
+
+## ✨ Features
+
+* ⚡ Instantly create new Neutralinojs applications
+* 🏃 Run apps locally with live reload
+* 📦 Build production-ready applications
+* 🔧 Minimal dependencies and fast execution
+* 🌍 Cross-platform support (Windows, Linux, macOS)
+
+---
+
+## 🚀 Installation
+
+Install globally using npm:
 
 ```bash
 npm install -g @neutralinojs/neu
 ```
 
-## Quick Start
+---
 
-Create a new Neutralinojs application:
+## ⚡ Quick Start
+
+### 1. Create a new app
 
 ```bash
 neu create myApp
 cd myApp
 ```
 
-Run the application:
+### 2. Run the app
 
 ```bash
 neu run
 ```
 
-Build the application:
+### 3. Build the app
 
 ```bash
 neu build
 ```
 
-### Requirements
+---
 
-- Node.js v12 or later version.
-- npm, yarn, or any Node.js package manager.
+## 🛠️ CLI Commands
 
-### License
+| Command      | Description                   |
+| ------------ | ----------------------------- |
+| `neu create` | Create a new Neutralinojs app |
+| `neu run`    | Run the application locally   |
+| `neu build`  | Build the application         |
+| `neu help`   | Show available commands       |
 
-[MIT](LICENSE)
+---
 
-### Contributing to Neutralinojs
+## 📂 Project Structure
 
-We really appreciate your code contributions. Please read [this contribution guide](https://neutralino.js.org/docs/contributing/framework-developer-guide#contribution-guidelines) before sending a pull request. Thank you for your contributions.
+```
+myApp/
+├── resources/
+├── neutralino.config.json
+├── index.html
+└── ...
+```
 
-#### ⚠️ Notice for contributors
+---
 
-Please note that we would like to keep this project's dependencies list minimal as possible. Make sure that you don't add new dependencies (external `npm` modules) with your pull requests. Also, don't use latest Node/JavaScript features that won't work on older Node.js versions. Thank you :tada:
+## ⚙️ Requirements
 
-### Contributors
+* Node.js >= 12.x
+* npm / yarn / pnpm
+* Supported OS: Windows, Linux, macOS
+
+---
+
+## 📚 Documentation
+
+* 📖 CLI Docs: https://neutralino.js.org/docs/cli/neu-cli/
+* 📝 Release Notes: https://neutralino.js.org/docs/release-notes/cli
+* 🤝 Contribution Guide: https://neutralino.js.org/docs/contributing/framework-developer-guide
+
+---
+
+## 🧩 Troubleshooting
+
+### ❌ `neu` command not found
+
+Make sure global npm packages are added to your system `PATH`.
+
+---
+
+### 🔐 Permission issues (Linux/macOS)
+
+Try installing with elevated permissions:
+
+```bash
+sudo npm install -g @neutralinojs/neu
+```
+
+---
+
+## 🤝 Contributing
+
+We really appreciate your contributions ❤️
+
+Before submitting a pull request, please read the official contribution guide:
+https://neutralino.js.org/docs/contributing/framework-developer-guide#contribution-guidelines
+
+### ⚠️ Notice for contributors
+
+* Keep dependencies minimal (avoid adding external npm modules)
+* Ensure compatibility with older Node.js versions
+* Follow existing code style and project philosophy
+
+---
+
+## 👥 Contributors
 
 <a href="https://github.com/neutralinojs/neutralinojs-cli/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=neutralinojs/neutralinojs-cli" />
 </a>
 
-Made with [contributors-img](https://contrib.rocks).
+---
+
+## 📄 License
+
+This project is licensed under the MIT License.


### PR DESCRIPTION
This PR adds a Quick Start section to the README to help new users quickly get started with the Neutralinojs CLI.

The section demonstrates how to:
- create a new Neutralinojs application
- run the application
- build the application

This improves onboarding for developers who are new to Neutralinojs.