### PR TITLE
fix(frontendlib): use logical OR instead of bitwise OR for waitTimeout default

### DIFF
--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -114,7 +114,7 @@ module.exports.containsFrontendLibApp = () => {
 module.exports.waitForFrontendLibApp = async () => {
     let configObj = config.get();
     let devUrlString = configObj.cli && configObj.cli.frontendLibrary ? configObj.cli.frontendLibrary.devUrl : undefined;
-    let timeout = configObj.cli && configObj.cli.frontendLibrary && configObj.cli.frontendLibrary.waitTimeout | 20000;
+    let timeout = (configObj.cli && configObj.cli.frontendLibrary && configObj.cli.frontendLibrary.waitTimeout) || 20000;
     let url = new URL(devUrlString);
     let portString = url.port;
     let port = portString ? Number.parseInt(portString) : getPortByProtocol(url.protocol)


### PR DESCRIPTION
#### Description
This PR replaces a bitwise OR operator (`|`) with a logical OR operator (`||`) in `src/modules/frontendlib.js`. 

The original use of the bitwise operator caused incorrect timeout calculations when a custom `waitTimeout` was provided in `neutralino.config.json` because it performed bit-masking instead of a logical fallback. For example, a configured value of `5000` resulted in an actual timeout of `24488`ms (`5000 | 20000`).

Fixes #401 

#### Changes
- Updated the `timeout` variable assignment to use `||` for proper fallback logic.

```javascript
let timeout = (configObj.cli && configObj.cli.frontendLibrary && configObj.cli.frontendLibrary.waitTimeout) || 20000;
```