### PR TITLE
fix: prevent pluginloader.js from removing globally installed packages

### DIFF
--- a/src/plugins/pluginloader.js
+++ b/src/plugins/pluginloader.js
@@ -123,33 +123,36 @@ module.exports.removeTest = async (pluginPath) => {
     pluginName = pluginPath;
   }
 
-  if (!pluginName && (!statsObj || !statsObj.isDirectory() || !fs.existsSync(pluginPath))) {
-    utils.error(`${pluginPath} is not a valid file path`);
-    process.exit(1);
-  } else {
-    packageJson = require(path.join(pluginPath, 'package.json'));
-    if (!packageJson) {
-      utils.error('Cannot find package.json file');
-      process.exit(1);
-    }
-
-    pluginName = packageJson.name;
-    if (!pluginName) {
-      utils.error('Your plugin has no name. Please add name in package.json');
-      process.exit(1);
-    }
-  }
-
   let plugins = [];
   if (config.has('plugins')) plugins = config.get('plugins');
 
+  if (!pluginName && (!statsObj || !statsObj.isDirectory() || !fs.existsSync(pluginPath))) {
+    utils.error(`${pluginPath} is not a valid file path`);
+    process.exit(1);
+  } else if(statsObj) {
+    try {
+        const packageJson = require(path.join(pluginPath, 'package.json'));
+        pluginName = packageJson.name;
+    } catch(e) {
+        utils.error('Cannot find package.json file');
+        process.exit(1);
+    }
+  }
+
+  if (!pluginName) {
+    utils.error('Your plugin has no name. Please add name in package.json');
+    process.exit(1);
+  }
+
   if (!plugins.includes(pluginName)) {
-    throw `Unable to find ${pluginName}!`;
+    utils.error(`Unable to find plugin: ${pluginName}`);
+    process.exit(1);
   }
 
   try {
-    
-    await execAsync(`npm rm -g ${pluginName}`);
+    if (isPluginInstalled(pluginName)) {
+        await execAsync(`npm unlink ${pluginName}`);
+    }
 
     await execAsync(`cd ${NEU_ROOT} && npm uninstall ${pluginName}`);
 


### PR DESCRIPTION
Description

This PR fixes an issue where the CLI unintentionally removed globally installed npm packages during plugin removal

The current implementation uses `npm rm -g`, which removes packages from the global environment instead of limiting the operation to the CLI or project scope. This leads to unintended system-wide deletions. During testing, a globally installed package was removed after running the plugin removal command

Fixes #403 

Changes
- Replaced the global uninstall command (`npm rm -g`) with a safer alternative to prevent unintended removal of globally installed packages.
```javascript
npm unlink ${pluginName}
```

- Added Existence Validation: Implemented a check to verify the plugin exists before removal. If a plugin is missing, the CLI now provides a clean `neu: ERRR Unable to find plugin` error instead of a stack trace crash
```javascript
if (!plugins.includes(pluginName)) {
    utils.error(`Unable to find plugin: ${pluginName}`);
    process.exit(1);
}

if (isPluginInstalled(pluginName)) {
    await execAsync(`npm unlink ${pluginName}`);
}
```


