### PR TITLE
fix: add HTTP status check in downloader.js and fix exit code in bundler.js

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -228,5 +228,6 @@ module.exports.bundleApp = async (options = {}) => {
     }
     catch (e) {
         utils.error(e.message.replace(/^Error: /g, ''));
+        process.exit(1);
     }
 }

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -141,12 +141,20 @@ let downloadClientFromRelease = (latest) => {
         getClientDownloadUrl(latest)
             .then((url) => {
                 https.get(url, function (response) {
+                    if(response.statusCode !== 200){
+                        file.close();
+                        reject(new Error(`Failed to download client: HTTP ${response.statusCode}`));
+                        return;
+                    }
                     response.pipe(file);
                     file.on('finish', () => {
                         file.close();
                         resolve();
                     });
-                });
+                }).on('error', (err) => {
+                    file.close();
+                    reject(err);
+                })
             });
     });
 }
@@ -160,12 +168,20 @@ let downloadTypesFromRelease = (latest) => {
         getTypesDownloadUrl(latest)
             .then((url) => {
                 https.get(url, function (response) {
+                    if(response.statusCode !== 200){
+                        file.close();
+                        reject(new Error(`Failed to download types: HTTP ${response.statusCode}`));
+                        return;
+                    }
                     response.pipe(file);
                     file.on('finish', () => {
                         file.close();
                         resolve();
                     });
-                });
+                }).on('error', (err) => {
+                    file.close();
+                    reject(err);
+                })
             });
     });
 }


### PR DESCRIPTION
Fixes #409
Fixes #407

Added HTTP status code checks and .on('error') handlers to downloadClientFromRelease() and downloadTypesFromRelease() 
in downloader.js.

Also included: process.exit(1) in bundler.js outer catch block when build fails.