### PR TITLE
fix: prevent sensitive data leakage from .storage during build

### DIFF
--- a/src/modules/bundler.js
+++ b/src/modules/bundler.js
@@ -10,6 +10,7 @@ const utils = require('../utils');
 const {patchWindowsExecutable} = require('./exepatch');
 const path = require('path');
 const {inject} = require('postject');
+const SENSITIVE_STORAGE_ITEMS = ['auth_info.json', 'tokens.json', '.env'];
 
 async function createAsarFile() {
     utils.log(`Generating ${constants.files.resourceFile}...`);
@@ -185,9 +186,19 @@ module.exports.bundleApp = async (options = {}) => {
         }
 
         if (options.copyStorage) {
+            utils.warn('Copying .storage directory. Please ensure that it does not contain any sensitive data.');
             utils.log('Copying storage data...');
             try {
-                fse.copySync('.storage', `${buildDir}/${binaryName}/.storage`);
+                fse.copySync('.storage', `${buildDir}/${binaryName}/.storage`, {
+                    filter: (src) => {
+                        const filename = path.basename(src);
+                        if (SENSITIVE_STORAGE_ITEMS.includes(filename)) {
+                            utils.warn(`Skipping sensitive file: ${filename}`);
+                            return false;
+                        }
+                        return true;
+                    }
+                });
             }
             catch (err) {
                 utils.error('Unable to copy storage data from the .storage directory. Please check if the directory exists');


### PR DESCRIPTION
Description
Prevent Sensitive Data Leakage from `.storage` during Build

This PR addresses a security vulnerability in the CLI bundler where sensitive development data (e.g., auth tokens, session state, environment variables) was accidentally leaked into production distributions when using the` --copy-storage flag`

Fixes #412 

Changes

1. Security Blacklist in `bundler.js` Implemented a `SENSITIVE_STORAGE_ITEMS` blacklist that automatically filters high-risk files during the directory copy process for eg these files 
- auth_info.json
- tokens.json
- .env


2. Proactive Security Warning
Added a user-facing warning that appears whenever the .storage directory is being packaged into a build, ensuring developers are aware of the potential for data inclusion.

The .storage directory is used by Neutralino apps at runtime to persist state. Developers often have their own testing credentials or environment secrets stored here locally. Packaging these into a production ZIP by default is a significant security risk that could lead to widespread credential leakage.

- Non-sensitive user settings (e.g., settings.json) are correctly preserved and copied.
- Sensitive files (e.g., auth_info.json) are detected, flagged, and skipped by the bundler.

Manual Verification Output:
```javascript
neu: WARN Copying .storage directory. Please ensure that it does not contain any sensitive data.
neu: INFO Copying storage data...
neu: WARN Skipping sensitive file: auth_info.json
```