### PR TITLE
fix: warn when favicon.ico is missing in generated project

### DIFF
--- a/src/modules/creator.js
+++ b/src/modules/creator.js
@@ -1,60 +1,69 @@
-const process = require('process');
-const path = require('path');
-const fs = require('fs');
-const fse = require('fs-extra');
-const config = require('../modules/config');
-const downloader = require('./downloader');
-const frontendlib = require('../modules/frontendlib');
-const hostproject = require('../modules/hostproject');
-const utils = require('../utils');
+const process = require('process')
+const path = require('path')
+const fs = require('fs')
+const fse = require('fs-extra')
+const config = require('../modules/config')
+const downloader = require('./downloader')
+const frontendlib = require('../modules/frontendlib')
+const hostproject = require('../modules/hostproject')
+const utils = require('../utils')
 
 module.exports.createApp = async (appPath, template) => {
-    const binaryName = path.basename(path.resolve(appPath));
+  const binaryName = path.basename(path.resolve(appPath))
 
-    if (utils.isNeutralinojsProject(appPath)) {
-        utils.error(`${appPath} directory already contains a Neutralinojs project.`);
-        process.exit(1);
-    }
+  if (utils.isNeutralinojsProject(appPath)) {
+    utils.error(`${appPath} directory already contains a Neutralinojs project.`)
+    process.exit(1)
+  }
 
-    if(!template) {
-        template = 'neutralinojs/neutralinojs-minimal';
-    }
+  if (!template) {
+    template = 'neutralinojs/neutralinojs-minimal'
+  }
 
-    utils.log(`Checking if ${template} is a valid Neutralinojs app template...`);
+  utils.log(`Checking if ${template} is a valid Neutralinojs app template...`)
 
-    const isValidTemplate = await downloader.isValidTemplate(template);
-    if(!isValidTemplate) {
-        utils.error(`${template} is not a valid Neutralinojs app template.`);
-        process.exit(1);
-    }
+  const isValidTemplate = await downloader.isValidTemplate(template)
+  if (!isValidTemplate) {
+    utils.error(`${template} is not a valid Neutralinojs app template.`)
+    process.exit(1)
+  }
 
-    utils.log(`Downloading ${template} template to ${binaryName} directory...`);
+  utils.log(`Downloading ${template} template to ${binaryName} directory...`)
 
-    fs.mkdirSync(appPath, { recursive: true });
-    process.chdir(appPath); // Change the path context for the following methods
+  fs.mkdirSync(appPath, { recursive: true })
+  process.chdir(appPath) // Change the path context for the following methods
 
-    try {
-        await downloader.downloadTemplate(template);
-        await downloader.downloadAndUpdateBinaries();
-        await downloader.downloadAndUpdateClient();
-    }
-    catch(err) {
-        utils.error('Unable to download resources from internet.' +
-                    ' Please check your internet connection and template URLs.');
-        process.exit(1);
-    }
+  try {
+    await downloader.downloadTemplate(template)
+    await downloader.downloadAndUpdateBinaries()
+    await downloader.downloadAndUpdateClient()
+  } catch (err) {
+    utils.error(
+      'Unable to download resources from internet.' +
+        ' Please check your internet connection and template URLs.',
+    )
+    process.exit(1)
+  }
 
-    config.update('cli.binaryName', binaryName);
-    config.update('modes.window.title', binaryName);
+  config.update('cli.binaryName', binaryName)
+  config.update('modes.window.title', binaryName)
 
-    if(frontendlib.containsFrontendLibApp()) {
-        await frontendlib.runCommand('initCommand');
-    }
+  if (frontendlib.containsFrontendLibApp()) {
+    await frontendlib.runCommand('initCommand')
+  }
 
-    if(hostproject.hasHostProject()) {
-        await hostproject.runCommand('initCommand');
-    }
+  if (hostproject.hasHostProject()) {
+    await hostproject.runCommand('initCommand')
+  }
 
-    console.log('-------');
-    utils.log(`Enter 'cd ${appPath} && neu run' to run your application.`);
+  console.log('-------')
+  utils.log(`Enter 'cd ${appPath} && neu run' to run your application.`)
+  // Check for missing favicon (improves developer experience)
+  const faviconPath = path.join(process.cwd(), 'resources', 'favicon.ico')
+
+  if (!fs.existsSync(faviconPath)) {
+    console.warn(
+      'WARNING: favicon.ico not found in /resources. This is optional but recommended.',
+    )
+  }
 }


### PR DESCRIPTION
### Related Issue

Fixes #415 

### Problem
When creating a new Neutralinojs application using:

neu create <app-name>
cd <app-name>
neu run

the application logs a runtime error:
Unable to load application resource file /resources/favicon.ico

### Root Cause

The default template (`neutralinojs/neutralinojs-minimal`) does not include a `favicon.ico` file in the `resources/` directory. This results in runtime error logs, which can be confusing for new users.

### Solution
This PR introduces a proactive check during project creation:

* Detects if `resources/favicon.ico` is missing
* Displays a clear warning message to the user instead of relying on runtime errors

### Changes Made

* Added a file existence check for `resources/favicon.ico` in:
src/modules/creator.js

* Displays the following warning if the file is missing:

Warning: favicon.ico not found in resources/. This file is optional but recommended.
### Impact

* Improves developer experience
* Reduces confusion caused by runtime error logs
* Provides clearer feedback to users without affecting existing functionality

### Testing

* Created a new project using `neu create`
* Verified that the warning message appears correctly
* Confirmed that existing functionality remains unchanged

### Note
A potential future improvement would be to include a default `favicon.ico` in the template repository to eliminate this issue entirely.
