### PR TITLE
fix: resolve() called after reject() on plugin install failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 ## Unreleased
 
 ### Bugfixes/improvements
+- Fix `resolve()` being called after `reject()` on install failure in the plugin loader.
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects
 - Skip patching the frontend library's main HTML file when it's defined as empty in the configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 ## Unreleased
 
 ### Bugfixes/improvements
-- Fix `resolve()` being called after `reject()` on install failure in the plugin loader.
 - Display the zipped binaries package size while downloading pre-built Neutralinojs binaries from GitHub releases.
 - Use the correct resources path for host projects
 - Skip patching the frontend library's main HTML file when it's defined as empty in the configuration

--- a/src/plugins/pluginloader.js
+++ b/src/plugins/pluginloader.js
@@ -41,9 +41,9 @@ let add = (pluginName) => {
         if(!isPluginInstalled(pluginName)) {
             exec(`cd ${NEU_ROOT} && npm install ${pluginName}`, (err, stdout, stderr) => {
                 if(err) {
-                    reject(stderr);
+                    return reject(stderr);
                 }
-                else if(!plugins.includes(pluginName)) {
+                if(!plugins.includes(pluginName)) {
                     plugins.push(pluginName);
                     config.set('plugins', plugins);
                 }


### PR DESCRIPTION
When npm install fails in pluginloader.add(), reject() was called but resolve() still ran unconditionally afterwards. Added return before reject() so the promise settles only once on error.
<img width="948" height="377" alt="image" src="https://github.com/user-attachments/assets/0aad0ff6-cda3-4e00-af2f-c29735d434d5" />
