### PR TITLE
fix: replace deprecated --load-dir-res with --res-mode=directory in runner.js

### DIFF
--- a/src/modules/runner.js
+++ b/src/modules/runner.js
@@ -27,7 +27,7 @@ module.exports.runApp = async (options = {}) => {
         }
 
         let binaryPath = `bin${path.sep}${binaryName}`;
-        let args = " --load-dir-res --path=. --export-auth-info --neu-dev-extension";
+        let args = " --res-mode=directory --path=. --export-auth-info --neu-dev-extension";
         if(options.argsOpt)
             args += " " + options.argsOpt;
 


### PR DESCRIPTION
### Description

`src/modules/runner.js` was passing the `--load-dir-res` flag to the Neutralinojs binary when running `neu run`. This flag is marked as **deprecated** in the framework core (`neutralinojs/settings.cpp`) in favor of the newer `--res-mode` flag, which supports all three resource modes (`directory`, `bundle`, and `embedded`).

```cpp
// neutralinojs/settings.cpp
// DEPRECATED: Resources read mode (resources.neu or from directory)
if(cliArg.key == "--load-dir-res") {
    resources::setMode(resources::ResourceModeDir);
    continue;
}
```

### Changes

Replaced `--load-dir-res` with `--res-mode=directory` in `src/modules/runner.js` to use the current supported flag.