### PR TITLE
Add initial builder command with validation support

### DIFF
--- a/src/commands/builder.js
+++ b/src/commands/builder.js
@@ -1,0 +1,17 @@
+module.exports.register = (program) => {
+    program
+        .command('builder <target>')
+        .description('Build installer for given target')
+        .action((target) => {
+
+            const validTargets = ['nsis', 'deb', 'appimage'];
+
+            if (!validTargets.includes(target)) {
+                console.log("Invalid target: " + target);
+                console.log("Supported: " + validTargets.join(', '));
+                return;
+            }
+
+            console.log("Building for " + target);
+        });
+};

--- a/src/neu-cli.js
+++ b/src/neu-cli.js
@@ -6,6 +6,7 @@ const version = require('../src/commands/version');
 const plugins = require('../src/commands/plugins');
 const pluginloader = require('../src/plugins/pluginloader');
 const modules = require('../src/modules');
+const builder = require('../src/commands/builder');
 
 module.exports.bootstrap = (program) => {
     create.register(program);
@@ -15,4 +16,5 @@ module.exports.bootstrap = (program) => {
     version.register(program);
     plugins.register(program);
     pluginloader.registerPlugins(program, modules);
+    builder.register(program);
 }


### PR DESCRIPTION
This PR introduces an initial implementation of the `builder` CLI command.

- Added new command: `neu builder <target>`
- Implemented validation for supported targets (nsis, deb, appimage)
- Provides clear error messages for invalid inputs

This serves as a starting point for the Neutralinojs builder plugin idea.