### PR TITLE
fix: handle offline/network errors in version command

### DIFF
--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -14,16 +14,22 @@ module.exports.register = (program) => {
             console.log(`neu CLI: v${package.version} ${latest ? '(latest)' : ''}`);
             if(utils.isNeutralinojsProject()) {
                 const configObj = config.get();
-                const latestBinVersion = await getRemoteLatestVersion('neutralinojs');
-                const latestLibVersion = await getRemoteLatestVersion('neutralino.js');
+                let latestBinVersion = null;
+                let latestLibVersion = null;
+                try {
+                    latestBinVersion = await getRemoteLatestVersion('neutralinojs');
+                    latestLibVersion = await getRemoteLatestVersion('neutralino.js');
+                }
+                catch(e) {
+                    utils.warn('Unable to fetch latest framework versions. Check your internet connection.');
+                }
                 const clientVersion = configObj.cli.clientVersion ? utils.getVersionTag(configObj.cli.clientVersion) :
                         'Installed from a package manager';
-                const latestBin = configObj.cli.binaryVersion == latestBinVersion;
-                const latestLib = configObj.cli.clientVersion ? (configObj.cli.clientVersion == latestLibVersion) : null;
-
+                const latestBin = latestBinVersion ? (configObj.cli.binaryVersion == latestBinVersion) : null;
+                const latestLib = (latestLibVersion && configObj.cli.clientVersion) ? (configObj.cli.clientVersion == latestLibVersion) : null;
                 console.log(`\n--- Project: ${configObj.cli.binaryName} (${configObj.applicationId}) ---`);
-                console.log(`Neutralinojs binaries: ${utils.getVersionTag(configObj.cli.binaryVersion)} ${latestBin ? '(latest)' : ''}`);
-                console.log(`Neutralinojs client: ${clientVersion} ${latestLib ? '(latest)' : ''}`);
+                console.log(`Neutralinojs binaries: ${utils.getVersionTag(configObj.cli.binaryVersion)} ${latestBin === true ? '(latest)' : latestBin === false ? '' : '(offline)'}`);
+                console.log(`Neutralinojs client: ${clientVersion} ${latestLib === true ? '(latest)' : latestLib === false ? '' : ''}`);
 
                 if(!latestBin || latestLib === false) {
                     utils.warn(`This project doesn't use the latest Neutralinojs framework. Run ` +

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,12 +47,19 @@ let checkCurrentProject = () => {
 
 let checkLatestVersion = () => {
     return new Promise((resolve) => {
+        const timer = setTimeout(() => resolve(true), 5000);
         exec(`npm view ${package.name} version`, (err, versionInfo) => {
+            clearTimeout(timer);
+            if (err || !versionInfo) {
+                resolve(true);
+                return;
+            }
             let latestVersion = versionInfo.trim();
-            if (!err && package.version !== latestVersion) {
+            if (package.version !== latestVersion) {
                 warn(`You are using an older neu CLI version. Install the latest version ` +
                     `by entering 'npm install -g ${package.name}'`);
                 resolve(false);
+                return;
             }
             resolve(true);
         });


### PR DESCRIPTION
- Add 5s timeout to checkLatestVersion to prevent hang when npm registry is unreachable
- Guard against null versionInfo to prevent TypeError crash
- Fix double resolve() call in checkLatestVersion promise
- Wrap getRemoteLatestVersion calls in version.js with try/catch to handle network failures gracefully
- Show '(offline)' indicator when version check is unavailable

Fixes: network error handling in neu version command