### PR TITLE
fix: collapse multiline template literal in WebSocket URL construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+### Bugfixes/improvements
+- Fix whitespace injection in WebSocket URL's extensionId query parameter.
+
 ## v11.7.2
 
 ### Bugfixes/improvements

--- a/src/modules/websocket.js
+++ b/src/modules/websocket.js
@@ -18,8 +18,7 @@ module.exports.start = (options = {}) => {
         return;
     }
 
-    ws = new WS(`ws://127.0.0.1:${authInfo.nlPort}?extensionId=js.neutralino.devtools
-                    &connectToken=${authInfo.nlConnectToken}`);
+    ws = new WS(`ws://127.0.0.1:${authInfo.nlPort}?extensionId=js.neutralino.devtools&connectToken=${authInfo.nlConnectToken}`);
 
     ws.onerror = () => {
         retryLater(options);


### PR DESCRIPTION
Closes [#399](https://github.com/neutralinojs/neutralinojs-cli/issues/399).

## The Bug

`src/modules/websocket.js` uses a multiline template literal to construct the WebSocket URL:

```js
ws = new WS(\`ws://127.0.0.1:${authInfo.nlPort}?extensionId=js.neutralino.devtools
                &connectToken=${authInfo.nlConnectToken}\`);
```

The newline and leading spaces between `extensionId` and `connectToken` become part of the URL, so the parsed `extensionId` value contains `"js.neutralino.devtools\n                "` instead of `"js.neutralino.devtools"`.

## The Fix

Collapse the template literal to a single line. No logic change.

## Checklist

- [x] Conventional Commit (`fix:`)
- [x] CHANGELOG updated under `Unreleased` → `Bugfixes/improvements`
- [x] No new dependencies added
- [x] No modern JS features used (stays compatible with Node.js 12+)