### PR TITLE
fix: reject promises when frontendLibrary/hostProject commands fail with non-zero exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+### Bugfixes/improvements
+- Properly reject promises when frontendLibrary or hostProject commands fail with a non-zero exit code.
+
 ## v11.7.2
 
 ### Bugfixes/improvements

--- a/src/modules/frontendlib.js
+++ b/src/modules/frontendlib.js
@@ -92,13 +92,18 @@ module.exports.runCommand = (commandKey) => {
     let frontendLib = configObj.cli ? configObj.cli.frontendLibrary : undefined;
 
     if(frontendLib && frontendLib.projectPath && frontendLib[commandKey]) {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
             let projectPath = utils.trimPath(frontendLib.projectPath);
             let cmd = frontendLib[commandKey];
 
             utils.log(`Running ${commandKey}: ${cmd}...`);
             const proc = spawnCommand(cmd, { stdio: 'inherit', cwd: projectPath });
             proc.on('exit', (code) => {
+                if(code !== 0) {
+                    utils.error(`frontendlib: ${commandKey} failed with exit code: ${code}`);
+                    reject(new Error(`Command failed with exit code ${code}`));
+                    return;
+                }
                 utils.log(`frontendlib: ${commandKey} completed with exit code: ${code}`);
                 resolve();
             });

--- a/src/modules/hostproject.js
+++ b/src/modules/hostproject.js
@@ -12,7 +12,7 @@ module.exports.runCommand = async (commandKey) => {
   let hostProject = configObj.cli ? configObj.cli.hostProject : undefined;
 
   if(hostProject && hostProject.projectPath && hostProject[commandKey]) {
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
           let projectPath = utils.trimPath(hostProject.projectPath);
           let cmd = hostProject[commandKey];
 
@@ -20,6 +20,11 @@ module.exports.runCommand = async (commandKey) => {
 
           const proc = spawnCommand(cmd, { stdio: 'inherit', cwd: projectPath});
           proc.on('exit', (code) => {
+              if(code !== 0) {
+                  utils.error(`hostproject: ${commandKey} failed with exit code: ${code}`);
+                  reject(new Error(`Command failed with exit code ${code}`));
+                  return;
+              }
               utils.log(`hostproject: ${commandKey} completed with exit code: ${code}`);
               resolve();
           });


### PR DESCRIPTION
Closes [#396](https://github.com/neutralinojs/neutralinojs-cli/issues/396).

## The Bug

`src/modules/frontendlib.js` and `src/modules/hostproject.js` both have `runCommand` functions that wrap `spawnCommand` in a Promise that **always calls `resolve()`**, regardless of the child process exit code:

```js
proc.on('exit', (code) => {
    utils.log(`...completed with exit code: ${code}`);
    resolve(); // called even when code !== 0
});
```

This means `neu build` and `neu run` continue silently after frontend build steps fail (compilation error, missing dependency, etc.), bundling a broken app and reporting success.

## The Fix

Check the exit code in both files. When non-zero, call `reject(new Error(...))` so callers can properly propagate the failure:

```js
proc.on('exit', (code) => {
    if(code !== 0) {
        utils.error(`...failed with exit code: ${code}`);
        reject(new Error(`Command failed with exit code ${code}`));
        return;
    }
    resolve();
});
```

## Checklist
- [x] Conventional Commit (`fix:`)
- [x] CHANGELOG updated under `Unreleased` → `Bugfixes/improvements`
- [x] No new dependencies added
- [x] No modern JS features used