### PR TITLE
fix: validate HTTP status code in downloadTemplate to reject non-200 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+### Bugfixes/improvements
+- Validate HTTP status code in `downloadTemplate` to reject non-200 responses instead of silently treating failures as success.
+
 ## v11.7.2
 
 ### Bugfixes/improvements

--- a/src/modules/downloader.js
+++ b/src/modules/downloader.js
@@ -193,6 +193,11 @@ module.exports.downloadTemplate = (template) => {
         const zipFilename = '.tmp/template.zip';
         const file = fs.createWriteStream(zipFilename);
         https.get(templateUrl, function (response) {
+            if(response.statusCode !== 200) {
+                file.close();
+                reject(new Error(`Failed to download template: HTTP ${response.statusCode}`));
+                return;
+            }
             response.pipe(file);
             response.on('end', () => {
                 utils.log('Extracting template zip file...');
@@ -204,7 +209,7 @@ module.exports.downloadTemplate = (template) => {
                     })
                     .catch((e) => reject(e));
             });
-        });
+        }).on('error', (err) => reject(err));
     });
 }
 


### PR DESCRIPTION
Closes [#370](https://github.com/neutralinojs/neutralinojs-cli/issues/370).

## The Bug

`downloadTemplate()` pipes the HTTP response directly to a file without checking `response.statusCode`. A 404 or 500 is silently treated as a successful download.

## The Fix

Added a status code check consistent with the pattern already used in `downloadClientFromRelease` and `downloadTypesFromRelease` (which were already fixed in an earlier commit):

```js
if(response.statusCode !== 200) {
    file.close();
    reject(new Error(`Failed to download template: HTTP ${response.statusCode}`));
    return;
}
```

## Checklist
- [x] Conventional Commit (`fix:`)
- [x] CHANGELOG updated
- [x] No new dependencies
- [x] No modern JS features